### PR TITLE
Fix Google browser sign in with Auth0 custom domain

### DIFF
--- a/src/background/useWindowService/openLogInWindow/listenForRedirects.ts
+++ b/src/background/useWindowService/openLogInWindow/listenForRedirects.ts
@@ -16,7 +16,10 @@ export default (
     const { url } = event;
     log.info(`Caught redirect in log in window: ${removeQueryParams(url)}`);
 
-    if (url.includes(`auth0.com/authorize`)) {
+    if (
+      url.includes(`auth0.com/authorize`) ||
+      url.includes(`auth.swivvel.io`)
+    ) {
       // The `swivvel://` protocol doesn't work in development environments,
       // so we have to perform the log in flow within Electron
       if (!isProduction()) {


### PR DESCRIPTION
## The Problem

We updated Auth0 to use a custom domain, but the Electron app is still listening for redirects to the old Auth0 domain, so the app is no longer redirecting users to their browser for the Google sign in flow.

## The Solution

Add the new custom Auth0 domain to the list of domains that we detect when determining whether a redirect should be opened in the browser. I left the old domain in there for now in case anyone is running old web code.