### PR TITLE
Send active status event on app start

### DIFF
--- a/src/background/pollForIdleTime.ts
+++ b/src/background/pollForIdleTime.ts
@@ -7,7 +7,7 @@ import log from 'electron-log';
 export default (transparentWindow: BrowserWindow): void => {
   log.info(`Configuring idle time polling...`);
 
-  let isIdle = false;
+  let isIdle: boolean | null = null;
 
   const interval = setInterval(async () => {
     if (transparentWindow.isDestroyed()) {


### PR DESCRIPTION
If you check out this  [PostHog session](https://app.posthog.com/replay/18ac6ec9e6023e5-0970b8e66f7f8a-4c517c27-16a7f0-18ac6ec9e618c8) you can see that Brian joined an audio room but was being shown as inactive. I dug into this a bit and saw that no active status event was sent to the backend.

The last status event we had for Brian was from the night before, and it was an IDLE event.

So Brian opened the desktop app, no ACTIVE event was fired to the backend and therefore he continued to show as idle.


As a solution, we can force the `isIdle` event to fire on app startup by initializing it as null. This way, an ACTIVE event will be fired on start up and override any IDLE event that may have been there at the end of the previous session.

NOTE: I realized this might not be a full solution. There is always the chance that the desktop app fires the isIdle event, but that event is never sent to the backend (maybe the user session expired, or the event is fired before the transparent window fully loads. In this case, there is no retry mechanism and the event is just lost. What we should do is implement some sort of queue or ACKing system. But this felt like a good amount more work, so I wanted to start with this and see if it gets us enough