### PR TITLE
Support Google Meet MVP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "electron-log": "^4.4.8",
         "electron-serve": "^1.1.0",
         "electron-store": "^8.1.0",
-        "electron-updater": "^6.1.4"
+        "electron-updater": "^6.1.4",
+        "ms": "^2.1.3"
       },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.7.0",
@@ -2035,6 +2036,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -5023,9 +5029,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "electron-log": "^4.4.8",
     "electron-serve": "^1.1.0",
     "electron-store": "^8.1.0",
-    "electron-updater": "^6.1.4"
+    "electron-updater": "^6.1.4",
+    "ms": "^2.1.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.0",

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -21,6 +21,7 @@ const run = async (): Promise<void> => {
     logInFlowCompleted: false,
     tray: null,
     windows: {
+      createGoogleMeet: null,
       hq: null,
       logIn: null,
       setup: null,

--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -22,6 +22,11 @@ export interface State {
    */
   windows: {
     /**
+     * Creates and joins a new Google Meet meeting
+     */
+    createGoogleMeet: BrowserWindow | null;
+
+    /**
      * The window that displays the HQ page of the web app
      */
     hq: BrowserWindow | null;

--- a/src/background/useWindowService/getWindowOpenRequestHandler.ts
+++ b/src/background/useWindowService/getWindowOpenRequestHandler.ts
@@ -3,6 +3,7 @@ import log from 'electron-log';
 
 import {
   getSiteUrl,
+  parseQueryParams,
   removeQueryParams,
   shouldOpenUrlInBrowser,
 } from '../utils';
@@ -17,6 +18,7 @@ export type WindowOpenRequestHandler = ({
  * Handle requests from the renderer process to open a specific Electron window.
  */
 export default (callbacks: {
+  onCreateGoogleMeetRequested: (podId: string) => void;
   onHqPageRequested: () => void;
   onLogInPageRequested: () => void;
   onSetupPageRequested: () => void;
@@ -25,6 +27,16 @@ export default (callbacks: {
     log.info(`Caught URL opened by window: ${url}`);
 
     const siteUrl = getSiteUrl();
+
+    if (removeQueryParams(url) === `${siteUrl}/electron/new-meet-for-pod`) {
+      log.info(`Create Google Meet page requested`);
+      const urlParams = parseQueryParams(url);
+      log.info(`URL params=${JSON.stringify(urlParams)}`);
+      const podId = urlParams.podId;
+      log.info(`Pod ID=${podId}`);
+      callbacks.onCreateGoogleMeetRequested(podId);
+      return { action: `deny` };
+    }
 
     if (removeQueryParams(url) === `${siteUrl}/electron/hq`) {
       log.info(`HQ page requested`);

--- a/src/background/useWindowService/openCreateGoogleMeetWindow/configureCloseHandler.ts
+++ b/src/background/useWindowService/openCreateGoogleMeetWindow/configureCloseHandler.ts
@@ -1,0 +1,15 @@
+import { BrowserWindow } from 'electron';
+import log from 'electron-log';
+
+import { State } from '../../types';
+
+export default (logInWindow: BrowserWindow, state: State): void => {
+  log.info(`Configuring window close handler...`);
+
+  logInWindow.on(`close`, () => {
+    log.info(`Create Google Meet window close event received`);
+    log.info(`Closing Create Google Meet window...`);
+
+    state.windows.createGoogleMeet = null;
+  });
+};

--- a/src/background/useWindowService/openCreateGoogleMeetWindow/getCreateGoogleMeetWindowBrowserOptions.ts
+++ b/src/background/useWindowService/openCreateGoogleMeetWindow/getCreateGoogleMeetWindowBrowserOptions.ts
@@ -4,8 +4,6 @@ import { getPreloadPath } from '../../utils';
 
 export default (): BrowserWindowConstructorOptions => {
   return {
-    height: 700,
     webPreferences: { preload: getPreloadPath() },
-    width: 720,
   };
 };

--- a/src/background/useWindowService/openCreateGoogleMeetWindow/getCreateGoogleMeetWindowBrowserOptions.ts
+++ b/src/background/useWindowService/openCreateGoogleMeetWindow/getCreateGoogleMeetWindowBrowserOptions.ts
@@ -1,0 +1,11 @@
+import { BrowserWindowConstructorOptions } from 'electron';
+
+import { getPreloadPath } from '../../utils';
+
+export default (): BrowserWindowConstructorOptions => {
+  return {
+    height: 700,
+    webPreferences: { preload: getPreloadPath() },
+    width: 720,
+  };
+};

--- a/src/background/useWindowService/openCreateGoogleMeetWindow/index.ts
+++ b/src/background/useWindowService/openCreateGoogleMeetWindow/index.ts
@@ -1,0 +1,3 @@
+import openCreateGoogleMeetWindow from './openCreateGoogleMeetWindow';
+
+export default openCreateGoogleMeetWindow;

--- a/src/background/useWindowService/openCreateGoogleMeetWindow/openCreateGoogleMeetWindow.ts
+++ b/src/background/useWindowService/openCreateGoogleMeetWindow/openCreateGoogleMeetWindow.ts
@@ -1,0 +1,32 @@
+import { loadUrl } from '../../utils';
+import { openBrowserWindow } from '../utils';
+
+import configureCloseHandler from './configureCloseHandler';
+import getCreateGoogleMeetWindowBrowserOptions from './getCreateGoogleMeetWindowBrowserOptions';
+import scrapeAndSaveMeetingUrl from './scrapeAndSaveMeetingUrl';
+import { OpenCreateGoogleMeetWindow } from './types';
+
+const openCreateGoogleMeetWindow: OpenCreateGoogleMeetWindow = async (args) => {
+  const { podId, state, windowOpenRequestHandler } = args;
+
+  const options = getCreateGoogleMeetWindowBrowserOptions();
+
+  return openBrowserWindow(
+    state,
+    `createGoogleMeet`,
+    options,
+    async (window) => {
+      window.webContents.setWindowOpenHandler(windowOpenRequestHandler);
+
+      configureCloseHandler(window, state);
+
+      await loadUrl(`https://meet.google.com/getalink`, window, state);
+
+      scrapeAndSaveMeetingUrl(window, state, podId);
+
+      return window;
+    }
+  );
+};
+
+export default openCreateGoogleMeetWindow;

--- a/src/background/useWindowService/openCreateGoogleMeetWindow/scrapeAndSaveMeetingUrl.ts
+++ b/src/background/useWindowService/openCreateGoogleMeetWindow/scrapeAndSaveMeetingUrl.ts
@@ -1,0 +1,54 @@
+import { BrowserWindow } from 'electron';
+import log from 'electron-log';
+import ms from 'ms';
+
+import { State } from '../../types';
+
+export default (window: BrowserWindow, state: State, podId: string): void => {
+  log.info(`Scraping and saving meeting URL for pod ${podId}...`);
+
+  const intervalStartTime = new Date().getTime();
+
+  const interval = setInterval(async () => {
+    const timeSinceIntervalStart = new Date().getTime() - intervalStartTime;
+
+    if (timeSinceIntervalStart > ms(`2 seconds`)) {
+      log.info(`Could not find meeting URL after 2 seconds, aborting`);
+      clearInterval(interval);
+      return;
+    }
+
+    const rawMeetingUrl = await window.webContents.executeJavaScript(
+      `document.querySelector('[data-meeting-link]').dataset.meetingLink`
+    );
+
+    if (rawMeetingUrl) {
+      const meetingUrl = rawMeetingUrl.startsWith(`http`)
+        ? rawMeetingUrl
+        : `https://${rawMeetingUrl}`;
+
+      log.info(`Found meeting URL for pod ${podId}: ${meetingUrl}`);
+
+      if (state.windows.transparent) {
+        log.info(`Sending meeting URL to transparent window...`);
+        state.windows.transparent.webContents.send(
+          `meetBreakoutUrlCreatedForPod`,
+          podId,
+          meetingUrl
+        );
+      } else {
+        log.info(`Transparent window not found, could not save meeting URL`);
+      }
+
+      log.info(`Clicking join...`);
+      await window.webContents.executeJavaScript(
+        `[...document.querySelectorAll('button')].find(button => button.textContent.toLowerCase().includes('join now'))?.click()`
+      );
+
+      log.info(`Closing window...`);
+      window.close();
+
+      clearInterval(interval);
+    }
+  }, 50);
+};

--- a/src/background/useWindowService/openCreateGoogleMeetWindow/scrapeAndSaveMeetingUrl.ts
+++ b/src/background/useWindowService/openCreateGoogleMeetWindow/scrapeAndSaveMeetingUrl.ts
@@ -12,8 +12,8 @@ export default (window: BrowserWindow, state: State, podId: string): void => {
   const interval = setInterval(async () => {
     const timeSinceIntervalStart = new Date().getTime() - intervalStartTime;
 
-    if (timeSinceIntervalStart > ms(`2 seconds`)) {
-      log.info(`Could not find meeting URL after 2 seconds, aborting`);
+    if (timeSinceIntervalStart > ms(`10 seconds`)) {
+      log.info(`Could not find meeting URL after 10 seconds, aborting`);
       clearInterval(interval);
       return;
     }

--- a/src/background/useWindowService/openCreateGoogleMeetWindow/types.ts
+++ b/src/background/useWindowService/openCreateGoogleMeetWindow/types.ts
@@ -1,0 +1,14 @@
+import { BrowserWindow } from 'electron';
+
+import { State } from '../../types';
+import { WindowOpenRequestHandler } from '../getWindowOpenRequestHandler';
+
+export type OpenCreateGoogleMeetWindow = (
+  args: OpenCreateGoogleMeetArgs
+) => Promise<BrowserWindow>;
+
+export interface OpenCreateGoogleMeetArgs {
+  podId: string;
+  state: State;
+  windowOpenRequestHandler: WindowOpenRequestHandler;
+}

--- a/src/background/useWindowService/useWindowService.ts
+++ b/src/background/useWindowService/useWindowService.ts
@@ -4,6 +4,7 @@ import { State } from '../types';
 import { TrayService } from '../useTrayService';
 
 import getWindowOpenRequestHandler from './getWindowOpenRequestHandler';
+import openCreateGoogleMeetWindow from './openCreateGoogleMeetWindow';
 import openHqWindow from './openHqWindow';
 import openLogInWindow from './openLogInWindow';
 import openSetupWindow from './openSetupWindow';
@@ -15,6 +16,9 @@ import { WindowService } from './types';
  */
 export default (state: State, trayService: TrayService): WindowService => {
   const windowOpenRequestHandler = getWindowOpenRequestHandler({
+    onCreateGoogleMeetRequested: (podId) => {
+      openCreateGoogleMeetWindow({ podId, state, windowOpenRequestHandler });
+    },
     onHqPageRequested: () => {
       openHqWindow({ state, trayService, windowOpenRequestHandler });
     },

--- a/src/background/utils/index.ts
+++ b/src/background/utils/index.ts
@@ -5,6 +5,7 @@ import getSiteUrl from './getSiteUrl';
 import isLinux from './isLinux';
 import isProduction from './isProduction';
 import loadUrl from './loadUrl';
+import parseQueryParams from './parseQueryParams';
 import prepareToQuitApp from './prepareToQuitApp';
 import quitApp from './quitApp';
 import removeQueryParams from './removeQueryParams';
@@ -20,6 +21,7 @@ export {
   isLinux,
   isProduction,
   loadUrl,
+  parseQueryParams,
   prepareToQuitApp,
   quitApp,
   removeQueryParams,

--- a/src/background/utils/parseQueryParams.ts
+++ b/src/background/utils/parseQueryParams.ts
@@ -1,0 +1,13 @@
+export default (url: string): Record<string, string> => {
+  // Return object containing all query params from URL where the keys are
+  // the query param names and the values are the query param values.
+  const u = new URL(url);
+
+  const queryParams: Record<string, string> = {};
+
+  u.searchParams.forEach((value, key) => {
+    queryParams[key] = value;
+  });
+
+  return queryParams;
+};

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,6 +3,10 @@ import { contextBridge, ipcRenderer } from 'electron';
 type IdleChangeCallback = (event: unknown, isIdle: boolean) => void;
 type JoinAudioRoomForPodCallback = (event: unknown, podId: string) => void;
 type LaunchAudioRoomFromSetupCallback = (event: unknown) => void;
+type MeetBreakoutUrlCreatedForPodCallback = (
+  event: unknown,
+  meetUrl: string
+) => void;
 
 // NOTE: values exposed in the main world should be added to window.d.ts
 // in the web app
@@ -59,6 +63,15 @@ contextBridge.exposeInMainWorld(`electron`, {
 
     return (): void => {
       ipcRenderer.removeListener(`launchAudioRoomFromSetup`, callback);
+    };
+  },
+  onMeetBreakoutUrlCreatedForPod: (
+    callback: MeetBreakoutUrlCreatedForPodCallback
+  ) => {
+    ipcRenderer.on(`meetBreakoutUrlCreatedForPod`, callback);
+
+    return (): void => {
+      ipcRenderer.removeListener(`meetBreakoutUrlCreatedForPod`, callback);
     };
   },
 });


### PR DESCRIPTION
## The Problem

Currently, Swivvel only supports teams that use Zoom. However, many teams use Google Meet instead.

## The Solution

Support a workflow where users can click a button in the web app to open a new Google Meet meeting.