### PR TITLE
Support Google Meet breakouts when asked for identity verification

### DIFF
--- a/src/background/useWindowService/openCreateGoogleMeetWindow/scrapeAndSaveMeetingUrl.ts
+++ b/src/background/useWindowService/openCreateGoogleMeetWindow/scrapeAndSaveMeetingUrl.ts
@@ -1,19 +1,14 @@
 import { BrowserWindow } from 'electron';
 import log from 'electron-log';
-import ms from 'ms';
 
 import { State } from '../../types';
 
 export default (window: BrowserWindow, state: State, podId: string): void => {
   log.info(`Scraping and saving meeting URL for pod ${podId}...`);
 
-  const intervalStartTime = new Date().getTime();
-
   const interval = setInterval(async () => {
-    const timeSinceIntervalStart = new Date().getTime() - intervalStartTime;
-
-    if (timeSinceIntervalStart > ms(`10 seconds`)) {
-      log.info(`Could not find meeting URL after 10 seconds, aborting`);
+    if (window.isDestroyed()) {
+      log.info(`Create Google Meet window destroyed, stopping interval`);
       clearInterval(interval);
       return;
     }


### PR DESCRIPTION
## The Problem

In commit ba8a01ee632a0d36f3fa117ead43b1ca7a98ebdc, we added support for opening a new Google Meet breakout room. This works by opening `https://meet.google.com/getalink` in an Electron window and automatically clicking the "Join" button.

When testing on production, one user received the following prompt before the `/getalink` page opened:

![image](https://github.com/swivvel/swivvel-electron/assets/119253005/91e47776-cd88-423d-8812-72f8c9e02b4b)

Since our desktop app couldn't find a "Join" button after 10 seconds, it gave up trying. Eventually the user confirmed their identity and got to the `/getalink` page, but by that point we were no longer looking for the "Join" button.

## The Solution

Don't give up on trying to find and click the "Join" button until the Electron window is closed.