### PR TITLE
Close windows on sleep; re-open on wake

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -50,7 +50,7 @@ const run = async (): Promise<void> => {
   trayService.createTray();
   configureAutoUpdates(state);
   pollForIdleTime(transparentWindow);
-  handlePowerMonitorStateChanges(state);
+  handlePowerMonitorStateChanges(state, windowService);
 
   log.info(`App started`);
 };

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -45,11 +45,11 @@ const run = async (): Promise<void> => {
   // Make sure handlers are registered before opening any windows
   configureIpcHandlers(windowService);
 
-  const transparentWindow = await windowService.openTransparentWindow();
+  await windowService.openTransparentWindow();
 
   trayService.createTray();
   configureAutoUpdates(state);
-  pollForIdleTime(transparentWindow);
+  pollForIdleTime(state);
   handlePowerMonitorStateChanges(state, windowService);
 
   log.info(`App started`);

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -6,7 +6,7 @@ import configureAppQuitHandling from './configureAppQuitHandling';
 import configureAutoUpdates from './configureAutoUpdates';
 import configureIpcHandlers from './configureIpcHandlers';
 import getDeepLinkHandler from './getDeepLinkHandler';
-import handleSystemShutdown from './handleSystemShutdown';
+import handlePowerMonitorStateChanges from './handlePowerMonitorStateChanges';
 import listenForDeepLinks from './listenForDeepLinks';
 import pollForIdleTime from './pollForIdleTime';
 import { State } from './types';
@@ -50,7 +50,7 @@ const run = async (): Promise<void> => {
   trayService.createTray();
   configureAutoUpdates(state);
   pollForIdleTime(transparentWindow);
-  handleSystemShutdown(state);
+  handlePowerMonitorStateChanges(state);
 
   log.info(`App started`);
 };

--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -5,6 +5,10 @@ import { State } from './types';
 import { quitApp } from './utils';
 
 export default (state: State): void => {
+  powerMonitor.on(`suspend`, () => {
+    log.info(`!!!!!!!!!!!!! SUSPEND !!!!!!!!!!!!!`);
+  });
+
   powerMonitor.on(`resume`, () => {
     log.info(`!!!!!!!!!!!!! RESUME !!!!!!!!!!!!!`);
   });

--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -28,8 +28,12 @@ export default (state: State): void => {
 
   powerMonitor.on(`suspend`, () => {
     log.info(`Power monitor: suspend detected`);
+    // Destroy the HQ window to help prevent it from getting in a bad state
+    // while the computer sleeps. It will get recreated when the transparent
+    // window refreshes when the computer wakes up.
     if (state.windows.hq) {
       state.windows.hq.destroy();
+      state.windows.hq = null;
     }
     refreshTransparentWindow();
   });

--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -5,18 +5,41 @@ import { State } from './types';
 import { quitApp } from './utils';
 
 export default (state: State): void => {
+  const refreshTransparentWindow = (): void => {
+    if (!state.windows.transparent) {
+      log.info(`No transparent window to refresh`);
+    } else if (state.windows.transparent?.isDestroyed()) {
+      log.info(`Transparent window is destroyed; not refreshing`);
+    } else {
+      log.info(`Refreshing transparent window`);
+      state.windows.transparent.reload();
+    }
+  };
+
+  // We have observed the app getting into a weird state when a Mac comes out
+  // of sleep mode. Opening the developer tools shows a blank Elements tab and
+  // nothing in the console, and clicking the "Join" button shows the spinner
+  // but hangs. This only happens on a very small subset of users, but in an
+  // attempt to fix it we're refreshing the transparent window whenever the
+  // computer sleeps and wakes. This is probably a good idea regardless of the
+  // bug because refreshing the transparent window will remove the user from the
+  // audio room, and if their computer is asleep then they aren't available to
+  // talk.
+
   powerMonitor.on(`suspend`, () => {
-    log.info(`!!!!!!!!!!!!! SUSPEND !!!!!!!!!!!!!`);
+    log.info(`Power monitor: suspend detected`);
+    refreshTransparentWindow();
   });
 
   powerMonitor.on(`resume`, () => {
-    log.info(`!!!!!!!!!!!!! RESUME !!!!!!!!!!!!!`);
+    log.info(`Power monitor: resume detected`);
+    refreshTransparentWindow();
   });
 
   // Without this, Macs would hang when trying to shut down because the
   // Swivvel app would never quit
   powerMonitor.on(`shutdown`, () => {
-    log.info(`System shutdown detected`);
+    log.info(`Power monitor: shutdown detected`);
     quitApp(state);
   });
 };

--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -4,10 +4,13 @@ import log from 'electron-log';
 import { State } from './types';
 import { quitApp } from './utils';
 
-/**
- * Make sure the app quits when the OS shuts down
- */
 export default (state: State): void => {
+  powerMonitor.on(`resume`, () => {
+    log.info(`!!!!!!!!!!!!! RESUME !!!!!!!!!!!!!`);
+  });
+
+  // Without this, Macs would hang when trying to shut down because the
+  // Swivvel app would never quit
   powerMonitor.on(`shutdown`, () => {
     log.info(`System shutdown detected`);
     quitApp(state);

--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -28,6 +28,9 @@ export default (state: State): void => {
 
   powerMonitor.on(`suspend`, () => {
     log.info(`Power monitor: suspend detected`);
+    if (state.windows.hq) {
+      state.windows.hq.destroy();
+    }
     refreshTransparentWindow();
   });
 

--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -2,9 +2,10 @@ import { powerMonitor } from 'electron';
 import log from 'electron-log';
 
 import { State } from './types';
+import { WindowService } from './useWindowService';
 import { quitApp } from './utils';
 
-export default (state: State): void => {
+export default (state: State, windowService: WindowService): void => {
   // We have observed the app getting into a weird state when a Mac comes out
   // of sleep mode. Opening the developer tools shows a blank Elements tab and
   // nothing in the console, and clicking the "Join" button shows the spinner
@@ -36,12 +37,12 @@ export default (state: State): void => {
 
   powerMonitor.on(`suspend`, () => {
     log.info(`Power monitor: suspend detected`);
-    refreshTransparentWindow();
+    windowService.closeAllWindows();
   });
 
   powerMonitor.on(`resume`, () => {
     log.info(`Power monitor: resume detected`);
-    refreshTransparentWindow();
+    windowService.openTransparentWindow();
   });
 
   // Without this, Macs would hang when trying to shut down because the

--- a/src/background/pollForIdleTime.ts
+++ b/src/background/pollForIdleTime.ts
@@ -1,5 +1,7 @@
-import { BrowserWindow, powerMonitor } from 'electron';
+import { powerMonitor } from 'electron';
 import log from 'electron-log';
+
+import { State } from './types';
 
 // Consider the user to be idle after this number of seconds
 const IDLE_THRESHOLD_SECONDS = 30;
@@ -7,24 +9,25 @@ const IDLE_THRESHOLD_SECONDS = 30;
 /**
  * Tell the web app when the user is idle.
  */
-export default (transparentWindow: BrowserWindow): void => {
+export default (state: State): void => {
   log.info(`Configuring idle time polling...`);
 
   let isIdle: boolean | null = null;
 
-  const interval = setInterval(async () => {
-    if (transparentWindow.isDestroyed()) {
-      log.info(`Transparent window destroyed; stopping idle time polling`);
-      clearInterval(interval);
-      return;
-    }
-
+  setInterval(async () => {
     const newIsIdle = powerMonitor.getSystemIdleTime() > IDLE_THRESHOLD_SECONDS;
 
     if (newIsIdle !== isIdle) {
       log.info(`Idle changed: ${isIdle} -> ${newIsIdle}`);
       isIdle = newIsIdle;
-      transparentWindow.webContents.send(`isIdle`, isIdle);
+
+      if (!state.windows.transparent) {
+        log.info(`Failed to report idle change: no transparent window`);
+      } else if (state.windows.transparent.isDestroyed()) {
+        log.info(`Failed to report idle change: transparent window destroyed`);
+      } else {
+        state.windows.transparent.webContents.send(`isIdle`, isIdle);
+      }
     }
   }, 1000);
 

--- a/src/background/useWindowService/types.ts
+++ b/src/background/useWindowService/types.ts
@@ -1,8 +1,7 @@
 import { BrowserWindow } from 'electron';
 
 export interface WindowService {
-  openHqWindow: () => Promise<BrowserWindow>;
+  closeAllWindows: () => void;
   openLogInWindow: () => Promise<BrowserWindow>;
-  openSetupWindow: () => Promise<BrowserWindow>;
   openTransparentWindow: () => Promise<BrowserWindow>;
 }

--- a/src/background/useWindowService/useWindowService.ts
+++ b/src/background/useWindowService/useWindowService.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow } from 'electron';
+import log from 'electron-log';
 
 import { State } from '../types';
 import { TrayService } from '../useTrayService';
@@ -10,6 +11,7 @@ import openLogInWindow from './openLogInWindow';
 import openSetupWindow from './openSetupWindow';
 import openTransparentWindow from './openTransparentWindow';
 import { WindowService } from './types';
+import { closeBrowserWindow } from './utils';
 
 /**
  * Service for interacting with windows managed by the Swivvel app.
@@ -31,14 +33,14 @@ export default (state: State, trayService: TrayService): WindowService => {
   });
 
   return {
-    openHqWindow: async (): Promise<BrowserWindow> => {
-      return openHqWindow({ state, trayService, windowOpenRequestHandler });
+    closeAllWindows: (): void => {
+      log.info(`Closing all windows...`);
+      Object.keys(state.windows).forEach((windowName) => {
+        closeBrowserWindow(state, windowName as keyof State['windows']);
+      });
     },
     openLogInWindow: async (): Promise<BrowserWindow> => {
       return openLogInWindow({ state, trayService, windowOpenRequestHandler });
-    },
-    openSetupWindow: async (): Promise<BrowserWindow> => {
-      return openSetupWindow({ state, trayService, windowOpenRequestHandler });
     },
     openTransparentWindow: async (): Promise<BrowserWindow> => {
       return openTransparentWindow({ state, windowOpenRequestHandler });

--- a/src/background/useWindowService/utils/closeBrowserWindow.ts
+++ b/src/background/useWindowService/utils/closeBrowserWindow.ts
@@ -1,0 +1,27 @@
+import log from 'electron-log';
+
+import { State } from '../../types';
+
+export default (
+  state: State,
+  browserWindowName: keyof State['windows']
+): void => {
+  log.info(`Close window: ${browserWindowName}`);
+
+  const existingWindow = state.windows[browserWindowName];
+
+  if (!existingWindow) {
+    log.info(`No existing window found: ${browserWindowName}`);
+    return;
+  }
+
+  if (existingWindow.isDestroyed()) {
+    log.info(`Window already destroyed: ${browserWindowName}`);
+    state.windows[browserWindowName] = null;
+    return;
+  }
+
+  log.info(`Destroying window: ${browserWindowName}`);
+  existingWindow.destroy();
+  state.windows[browserWindowName] = null;
+};

--- a/src/background/useWindowService/utils/index.ts
+++ b/src/background/useWindowService/utils/index.ts
@@ -1,3 +1,4 @@
+import closeBrowserWindow from './closeBrowserWindow';
 import openBrowserWindow from './openBrowserWindow';
 
-export { openBrowserWindow };
+export { closeBrowserWindow, openBrowserWindow };


### PR DESCRIPTION
Closing the windows on sleep and re-opening them on resume solves (or attempts to solve) a handful of issues:

1. We have observed (in a very small subset of users) the app getting into a weird state when a Mac comes out of sleep mode. Opening the developer tools shows blank Elements and Console tabs, and clicking the "Join" button shows the spinner but hangs.
2. We have received various error alerts at late times of the night that seem to indicate that the app is unable to fetch data from our back end. Our assumption is that the computer is asleep and this is causing some kind of connectivity problem.
3. For many users, their computer sleeps overnight. Closing and re-opening the windows can make sure that the client has the latest version of the web app code when the user resumes their computer in the morning.
4. If a user has no activity over the weekend, Auth0 will expire their session. We don't currently handle this very well - the app can end up displaying an "Access Denied" page. Closing and re-opening the windows will make sure that an unauthenticated user is presented with the log in page when they resume their computer on Monday morning.
