### PR TITLE
Close windows on lock; re-open on unlock

### DIFF
--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -6,7 +6,7 @@ import { WindowService } from './useWindowService';
 import { quitApp } from './utils';
 
 export default (state: State, windowService: WindowService): void => {
-  // Closing the windows on sleep and re-opening them on resume solves (or
+  // Closing the windows on lock/sleep and re-opening them on resume solves (or
   // attempts to solve) a handful of issues:
   //
   // 1. We have observed (in a very small subset of users) the app getting into
@@ -26,9 +26,17 @@ export default (state: State, windowService: WindowService): void => {
   //    windows will make sure that an unauthenticated user is presented with
   //    the log in page when they resume their computer on Monday morning.
   //
+  powerMonitor.on(`lock-screen`, () => {
+    log.info(`Power monitor: lock-screen detected`);
+    windowService.closeAllWindows();
+  });
   powerMonitor.on(`suspend`, () => {
     log.info(`Power monitor: suspend detected`);
     windowService.closeAllWindows();
+  });
+  powerMonitor.on(`unlock-screen`, () => {
+    log.info(`Power monitor: unlock-screen detected`);
+    windowService.openTransparentWindow();
   });
   powerMonitor.on(`resume`, () => {
     log.info(`Power monitor: resume detected`);

--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -10,21 +10,23 @@ export default (state: State, windowService: WindowService): void => {
   // attempts to solve) a handful of issues:
   //
   // 1. We have observed (in a very small subset of users) the app getting into
-  //    a weird state when a Mac comes out of sleep mode. Opening the developer
+  //    a weird state when a Mac is locked overnight. Opening the developer
   //    tools shows blank Elements and Console tabs, and clicking the "Join"
   //    button shows the spinner but hangs.
   // 2. We have received various error alerts at late times of the night that
   //    seem to indicate that the app is unable to fetch data from our back end.
   //    Our assumption is that the computer is asleep and this is causing some
   //    kind of connectivity problem.
-  // 3. For many users, their computer sleeps overnight. Closing and re-opening
-  //    the windows can make sure that the client has the latest version of the
-  //    web app code when the user resumes their computer in the morning.
+  // 3. Many users keep their computer on overnight, but in sleep mode or
+  //    locked. Closing and re-opening the windows can make sure that the client
+  //    has the latest version of the web app code when the user unlocks/resumes
+  //    their computer in the morning.
   // 4. If a user has no activity over the weekend, Auth0 will expire their
   //    session. We don't currently handle this very well - the app can end
   //    up displaying an "Access Denied" page. Closing and re-opening the
   //    windows will make sure that an unauthenticated user is presented with
-  //    the log in page when they resume their computer on Monday morning.
+  //    the log in page when they unlock/resume their computer on Monday
+  //    morning.
   //
   powerMonitor.on(`lock-screen`, () => {
     log.info(`Power monitor: lock-screen detected`);


### PR DESCRIPTION
## The Problem

In commit e08c30a4a2d50ef604d2845288fae7e2405cf276, we made it so all of the Electron windows close when a user's computer goes to sleep and then re-open when the computer wakes.

There were many reasons for this (see the commit description), but one was that the app would get in a bad state when users started their day after keeping the app open all night. We assumed this was because the computer was going to sleep, but after releasing this fix some users were still getting into the bad state in the morning. It turns out that these users were locking their screens, not sleeping their computer.

## The Solution

Update the window close/re-open logic to run both on sleep/wake _and_ lock/unlock.