### PR TITLE
Retry loading of notifications URL into transparent window

### DIFF
--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -28,7 +28,12 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
     pollForMouseEvents(window);
     resizeOnDisplayChange(window);
 
-    await loadUrl(`${getSiteUrl()}/notifications`, window, state);
+    await loadUrl(`${getSiteUrl()}/notifications`, window, state, {
+      // The transparent window is core to the application because it's
+      // responsible for opening all of the other windows and displaying the
+      // audio room. Retry loading the URL indefinitely if it fails.
+      retry: true,
+    });
 
     return window;
   });


### PR DESCRIPTION
## The Problem

In commit 77b5b8801796eba17334edf70e267935c459c267, we implemented logic to close all of the Electron windows when the computer is locked and re-open them when the computer is unlocked. However, sometimes on unlock (or resume) users get the following error:

![image](https://github.com/swivvel/swivvel-electron/assets/119253005/c0c9043d-207d-4175-a638-d93ab5436ce7)

and then the Swivvel app closes.

Best guess is that the network connection is inactive and the transparent window fails to open.

## The Solution

There could be any number of reasons that the transparent window fails to load, many of them just temporary issues. To solve the issue above, as well as any other temporary failure, this commit introduces a retry mechanism when loading the transparent window page.