### PR TITLE
Buffer idle status change events

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -42,14 +42,15 @@ const run = async (): Promise<void> => {
     await systemPreferences.askForMediaAccess(`microphone`);
   }
 
-  // Make sure handlers are registered before opening any windows
+  // These functions set up IPC handlers that must be registered before the
+  // transparent window loads
   configureIpcHandlers(windowService);
+  pollForIdleTime(state);
 
   await windowService.openTransparentWindow();
 
   trayService.createTray();
   configureAutoUpdates(state);
-  pollForIdleTime(state);
   handlePowerMonitorStateChanges(state, windowService);
 
   log.info(`App started`);

--- a/src/background/configureIpcHandlers.ts
+++ b/src/background/configureIpcHandlers.ts
@@ -11,14 +11,17 @@ export default (windowService: WindowService): void => {
 
   ipcMain.handle(`isProduction`, isProduction);
 
-  ipcMain.on(`joinAudioRoomForPod`, async (event, podId): Promise<void> => {
-    log.info(`Received joinAudioRoomForPod event, podId=${podId}`);
+  ipcMain.on(
+    `joinAudioRoomForPod`,
+    async (event, podId: string): Promise<void> => {
+      log.info(`Received joinAudioRoomForPod event, podId=${podId}`);
 
-    const transparentWindow = await windowService.openTransparentWindow();
+      const transparentWindow = await windowService.openTransparentWindow();
 
-    log.info(`Sending joinAudioRoomForPod event to transparent window`);
-    transparentWindow.webContents.send(`joinAudioRoomForPod`, podId);
-  });
+      log.info(`Sending joinAudioRoomForPod event to transparent window`);
+      transparentWindow.webContents.send(`joinAudioRoomForPod`, podId);
+    }
+  );
 
   ipcMain.on(`launchAudioRoomFromSetup`, async (): Promise<void> => {
     log.info(`Received launchAudioRoomFromSetup event`);

--- a/src/background/pollForIdleTime.ts
+++ b/src/background/pollForIdleTime.ts
@@ -14,9 +14,9 @@ interface IdleChangeEvent {
 // The transparent window is responsible for sending idle change events to the
 // server. However, sometimes the transparent window isn't available or is
 // unable to contact the server. To avoid losing idle change events, we put
-// them all in a buffer and inform the transparent window that there are events
-// that need to be synced. The transparent window fetches and syncs these events
-// when it is ready.
+// them all in a buffer and continually attempt to send that buffer to the
+// transparent window. After the transparent window successfully syncs an event,
+// it informs the Electron app, which then removes the event from the buffer.
 const buffer = new Map<string, IdleChangeEvent>();
 
 const getKey = (idleChangeEvent: IdleChangeEvent): string => {

--- a/src/background/pollForIdleTime.ts
+++ b/src/background/pollForIdleTime.ts
@@ -1,10 +1,27 @@
-import { powerMonitor } from 'electron';
+import { ipcMain, powerMonitor } from 'electron';
 import log from 'electron-log';
 
 import { State } from './types';
 
 // Consider the user to be idle after this number of seconds
 const IDLE_THRESHOLD_SECONDS = 30;
+
+interface IdleChangeEvent {
+  isIdle: boolean;
+  timestamp: number;
+}
+
+// The transparent window is responsible for sending idle change events to the
+// server. However, sometimes the transparent window isn't available or is
+// unable to contact the server. To avoid losing idle change events, we put
+// them all in a buffer and inform the transparent window that there are events
+// that need to be synced. The transparent window fetches and syncs these events
+// when it is ready.
+const buffer = new Map<string, IdleChangeEvent>();
+
+const getKey = (idleChangeEvent: IdleChangeEvent): string => {
+  return `${idleChangeEvent.isIdle}-${idleChangeEvent.timestamp}`;
+};
 
 /**
  * Tell the web app when the user is idle.
@@ -20,16 +37,46 @@ export default (state: State): void => {
     if (newIsIdle !== isIdle) {
       log.info(`Idle changed: ${isIdle} -> ${newIsIdle}`);
       isIdle = newIsIdle;
+      const idleChangeEvent = { isIdle, timestamp: new Date().getTime() };
+      log.info(`Adding idle change event to buffer: ${idleChangeEvent}`);
+      buffer.set(getKey(idleChangeEvent), idleChangeEvent);
+    }
 
+    if (buffer.size > 0) {
+      log.info(`Idle change events buffered: ${buffer.size}`);
       if (!state.windows.transparent) {
         log.info(`Failed to report idle change: no transparent window`);
       } else if (state.windows.transparent.isDestroyed()) {
         log.info(`Failed to report idle change: transparent window destroyed`);
       } else {
-        state.windows.transparent.webContents.send(`isIdle`, isIdle);
+        log.info(`Reporting idle change to transparent window...`);
+        state.windows.transparent.webContents.send(
+          `idleChangeEventsBuffered`,
+          Array.from(buffer.values())
+        );
       }
     }
   }, 1000);
+
+  ipcMain.on(
+    `idleChangeEventsSynced`,
+    async (event, idleChangeEvents: Array<IdleChangeEvent>): Promise<void> => {
+      log.info(
+        `Received idleChangeEventsSynced event, num synced=${idleChangeEvents.length}`
+      );
+
+      let numRemoved = 0;
+
+      idleChangeEvents.forEach((idleChangeEvent) => {
+        const removed = buffer.delete(getKey(idleChangeEvent));
+        if (removed) {
+          numRemoved += 1;
+        }
+      });
+
+      log.info(`Removed ${numRemoved} idle change events from buffer`);
+    }
+  );
 
   log.info(`Configured idle time polling`);
 };

--- a/src/background/pollForIdleTime.ts
+++ b/src/background/pollForIdleTime.ts
@@ -38,7 +38,8 @@ export default (state: State): void => {
       log.info(`Idle changed: ${isIdle} -> ${newIsIdle}`);
       isIdle = newIsIdle;
       const idleChangeEvent = { isIdle, timestamp: new Date().getTime() };
-      log.info(`Adding idle change event to buffer: ${idleChangeEvent}`);
+      const key = getKey(idleChangeEvent);
+      log.info(`Adding idle change event to buffer: ${key}`);
       buffer.set(getKey(idleChangeEvent), idleChangeEvent);
     }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,6 +1,137 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+// NOTE: values exposed in the main world should be added to window.d.ts
+// in the web app
+
+contextBridge.exposeInMainWorld(`electron`, {
+  /**
+   * Deprecated: remove when all clients on v1.2.0
+   */
+  featureFlags: { loginFlowV2: true },
+
+  /**
+   * Return desktop app version from package.json (note: returns Electron
+   * version in development)
+   */
+  getDesktopAppVersion: (): Promise<string> => {
+    return ipcRenderer.invoke(`getDesktopAppVersion`);
+  },
+
+  /**
+   * Return true if desktop app is packaged (note: not the same as NODE_ENV)
+   */
+  getIsProduction: (): Promise<boolean> => {
+    return ipcRenderer.invoke(`isProduction`);
+  },
+
+  /**
+   * True if desktop app is running on Linux
+   */
+  isLinux: process.platform === `linux`,
+
+  /**
+   * Inform the transparent window that the user is requesting to join the
+   * audio room for the given pod. Allows users to join audio room from other
+   * windows.
+   */
+  joinAudioRoomForPod: (podId: string) => {
+    ipcRenderer.send(`joinAudioRoomForPod`, podId);
+  },
+
+  /**
+   * Inform the transparent window that the user is requesting to launch the
+   * audio room from the setup flow (i.e. `<DesktopAppSetup>`). The setup flow
+   * can't use `joinAudioRoomForPod` because the audio room widget hasn't been
+   * opened yet.
+   */
+  launchAudioRoomFromSetup: () => {
+    ipcRenderer.send(`launchAudioRoomFromSetup`);
+  },
+
+  /**
+   * Deprecated: remove when all clients on v1.2.4
+   */
+  offIdleChange: (callback: IdleChangeCallback) => {
+    ipcRenderer.off(`isIdle`, callback);
+  },
+
+  /**
+   * Deprecated: remove when all clients on v1.2.4
+   */
+  onIdleChange: (callback: IdleChangeCallback) => {
+    ipcRenderer.on(`isIdle`, callback);
+  },
+
+  /**
+   * Deprecated: remove when all clients on v1.2.16
+   */
+  onIdleChange2: (callback: IdleChangeCallback) => {
+    ipcRenderer.on(`isIdle`, callback);
+    return (): void => {
+      ipcRenderer.removeListener(`isIdle`, callback);
+    };
+  },
+
+  /**
+   * Listener allowing the transparent window to know when there are idle
+   * change events that need to be synced.
+   */
+  onIdleChangeEventsBuffered: (callback: IdleChangeEventsBufferedCallback) => {
+    ipcRenderer.on(`idleChangeEventsBuffered`, callback);
+    return (): void => {
+      ipcRenderer.removeListener(`idleChangeEventsBuffered`, callback);
+    };
+  },
+
+  /**
+   * Used by the transparent window to inform the idle poller that idle change
+   * events have been synced to the server.
+   */
+  onIdleChangeEventsSynced: (idleChangeEvents: Array<IdleChangeEvent>) => {
+    ipcRenderer.send(`idleChangeEventsSynced`, idleChangeEvents);
+  },
+
+  /**
+   * Listener allowing the transparent window to know when the user has
+   * requested to join the audio room for a pod.
+   */
+  onJoinAudioRoomForPod: (callback: JoinAudioRoomForPodCallback) => {
+    ipcRenderer.on(`joinAudioRoomForPod`, callback);
+    return (): void => {
+      ipcRenderer.removeListener(`joinAudioRoomForPod`, callback);
+    };
+  },
+
+  /**
+   * Listener allowing the transparent window to know when the user has
+   * requested to launch the audio room during the setup flow.
+   */
+  onLaunchAudioRoomFromSetup: (callback: LaunchAudioRoomFromSetupCallback) => {
+    ipcRenderer.on(`launchAudioRoomFromSetup`, callback);
+    return (): void => {
+      ipcRenderer.removeListener(`launchAudioRoomFromSetup`, callback);
+    };
+  },
+
+  /**
+   * Listener allowing the transparent window to know when the user has
+   * created a new Google Meet breakout room URL for a pod.
+   */
+  onMeetBreakoutUrlCreatedForPod: (
+    callback: MeetBreakoutUrlCreatedForPodCallback
+  ) => {
+    ipcRenderer.on(`meetBreakoutUrlCreatedForPod`, callback);
+    return (): void => {
+      ipcRenderer.removeListener(`meetBreakoutUrlCreatedForPod`, callback);
+    };
+  },
+});
+
 type IdleChangeCallback = (event: unknown, isIdle: boolean) => void;
+type IdleChangeEventsBufferedCallback = (
+  event: unknown,
+  idleChangeEvents: Array<IdleChangeEvent>
+) => void;
 type JoinAudioRoomForPodCallback = (event: unknown, podId: string) => void;
 type LaunchAudioRoomFromSetupCallback = (event: unknown) => void;
 type MeetBreakoutUrlCreatedForPodCallback = (
@@ -8,70 +139,7 @@ type MeetBreakoutUrlCreatedForPodCallback = (
   meetUrl: string
 ) => void;
 
-// NOTE: values exposed in the main world should be added to window.d.ts
-// in the web app
-
-contextBridge.exposeInMainWorld(`electron`, {
-  // Feature flags can be used to gate features in the renderer if they would
-  // be incompatible with old versions of the desktop app
-  featureFlags: {
-    // The log in flow that sends users to the browser to reuse their existing
-    // Google session so they don't have to type their password
-    loginFlowV2: true,
-  },
-  getIsProduction: (): Promise<boolean> => {
-    return ipcRenderer.invoke(`isProduction`);
-  },
-  getDesktopAppVersion: (): Promise<string> => {
-    return ipcRenderer.invoke(`getDesktopAppVersion`);
-  },
-  isLinux: process.platform === `linux`,
-  joinAudioRoomForPod: (podId: string) => {
-    ipcRenderer.send(`joinAudioRoomForPod`, podId);
-  },
-  launchAudioRoomFromSetup: () => {
-    ipcRenderer.send(`launchAudioRoomFromSetup`);
-  },
-  offIdleChange: (callback: IdleChangeCallback) => {
-    ipcRenderer.off(`isIdle`, callback);
-  },
-  onIdleChange: (callback: IdleChangeCallback) => {
-    ipcRenderer.on(`isIdle`, callback);
-  },
-  // We discovered that the `callback` passed from the web app gets modified
-  // in some way before it reaches the preload script, causing calls to
-  // `removeListener` to do nothing because they can't find a matching callback.
-  // To work around this, our event handlers now return a function that can be
-  // used to remove the listener, but we had to maintain the old idle-change
-  // fields for backwards compatibility with old desktop clients.
-  onIdleChange2: (callback: IdleChangeCallback) => {
-    ipcRenderer.on(`isIdle`, callback);
-
-    return (): void => {
-      ipcRenderer.removeListener(`isIdle`, callback);
-    };
-  },
-  onJoinAudioRoomForPod: (callback: JoinAudioRoomForPodCallback) => {
-    ipcRenderer.on(`joinAudioRoomForPod`, callback);
-
-    return (): void => {
-      ipcRenderer.removeListener(`joinAudioRoomForPod`, callback);
-    };
-  },
-  onLaunchAudioRoomFromSetup: (callback: LaunchAudioRoomFromSetupCallback) => {
-    ipcRenderer.on(`launchAudioRoomFromSetup`, callback);
-
-    return (): void => {
-      ipcRenderer.removeListener(`launchAudioRoomFromSetup`, callback);
-    };
-  },
-  onMeetBreakoutUrlCreatedForPod: (
-    callback: MeetBreakoutUrlCreatedForPodCallback
-  ) => {
-    ipcRenderer.on(`meetBreakoutUrlCreatedForPod`, callback);
-
-    return (): void => {
-      ipcRenderer.removeListener(`meetBreakoutUrlCreatedForPod`, callback);
-    };
-  },
-});
+interface IdleChangeEvent {
+  isIdle: boolean;
+  timestamp: number;
+}


### PR DESCRIPTION
## The Problem

The transparent window is responsible for sending idle change events to the server. However, sometimes the transparent window isn't available or is unable to contact the server. This is currently causing us to drop idle status change events, resulting in users appearing to be idle when they are not.

## The Solution

To avoid losing idle change events, we now put them all in a buffer and continually attempt to send that buffer to the transparent window. After the transparent window successfully syncs an event, it informs the Electron app, which then removes the event from the buffer.