### PR TITLE
Add video to mac entitlements list

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -10,5 +10,7 @@
 		<true/>
 		<key>com.apple.security.device.audio-input</key>
 		<true/>
+		<key>com.apple.security.device.camera</key>
+		<true/>
 	</dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
       "entitlements": "./build/entitlements.mac.plist",
       "extendInfo": {
         "NSMicrophoneUsageDescription": "Swivvel uses your microphone for your team's audio room",
-        "com.apple.security.device.audio-input": true
+        "NSCameraUsageDescription": "Swivvel uses your camera for video breakouts from your team's audio room",
+        "com.apple.security.device.audio-input": true,
+        "com.apple.security.device.camera": true
       }
     },
     "win": {

--- a/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
@@ -1,3 +1,4 @@
+import { systemPreferences } from 'electron';
 import log from 'electron-log';
 
 import { loadUrl } from '../../utils';
@@ -26,6 +27,11 @@ const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
       configureCloseHandler(window, state);
 
       let meetingUrlToOpen: string | null = meetingUrl;
+
+      if (systemPreferences.askForMediaAccess) {
+        log.info(`Asking for camera access`);
+        await systemPreferences.askForMediaAccess(`camera`);
+      }
 
       if (!meetingUrlToOpen) {
         await loadUrl(`https://meet.google.com/getalink`, window, state);


### PR DESCRIPTION
Video for Google Meets is not working on the Mac. It is working for me when I build locally. I think this is because I did not include video in the app's entitlement list.