### PR TITLE
Handle URL load errors more gracefully; improve logging

### DIFF
--- a/src/background/getDeepLinkHandler.ts
+++ b/src/background/getDeepLinkHandler.ts
@@ -20,7 +20,12 @@ export default (
       const logInWindow = await windowService.openLogInWindow();
 
       log.info(`Loading OAuth callback URL into log in window...`);
-      await loadUrl(convertDeepLinkUrlToHttps(url), logInWindow, state);
+      await loadUrl(convertDeepLinkUrlToHttps(url), logInWindow, state, {
+        // There is no easy way to recover if the OAuth callback URL fails to
+        // load, so just close the app so that the user is re-prompted to log
+        // in when they open it again.
+        onError: `warnAndQuitApp`,
+      });
       log.info(`Loaded OAuth callback URL into log in window`);
 
       // After the OAuth URL loads, the log in window will catch a redirect

--- a/src/background/pollForIdleTime.ts
+++ b/src/background/pollForIdleTime.ts
@@ -45,11 +45,15 @@ export default (state: State): void => {
 
     if (buffer.size > 0) {
       log.info(`Idle change events buffered: ${buffer.size}`);
-      if (!state.windows.transparent) {
-        log.info(`Failed to report idle change: no transparent window`);
-      } else if (state.windows.transparent.isDestroyed()) {
-        log.info(`Failed to report idle change: transparent window destroyed`);
-      } else {
+
+      // Note: we are purposefully not logging when the transparent window is
+      // missing because we close the transparent window when someone locks
+      // or sleeps their computer, so we could end up writing a log line every
+      // second for hours.
+      if (
+        state.windows.transparent &&
+        !state.windows.transparent.isDestroyed()
+      ) {
         log.info(`Reporting idle change to transparent window...`);
         state.windows.transparent.webContents.send(
           `idleChangeEventsBuffered`,

--- a/src/background/useWindowService/openGoogleMeetWindow/loadMeetingUrl.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/loadMeetingUrl.ts
@@ -10,7 +10,13 @@ export default async (
   window: BrowserWindow,
   state: State
 ): Promise<void> => {
-  await loadUrl(url, window, state);
+  await loadUrl(url, window, state, {
+    // Since the Google Meet window is opened from a user action, we must
+    // display an error message to inform the user that their action failed.
+    // Since the Google Meet window is temporary and the user can retry the
+    // action, we can just destroy the window so the user tries again.
+    onError: `warnAndDestroyWindow`,
+  });
 
   // Out of the box, screen-sharing within the Meet does not work. To get around
   // this, we need to patch the window.getDisplayMedia function, which is

--- a/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
@@ -34,7 +34,14 @@ const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
       }
 
       if (!meetingUrlToOpen) {
-        await loadUrl(`https://meet.google.com/getalink`, window, state);
+        await loadUrl(`https://meet.google.com/getalink`, window, state, {
+          // Since the Google Meet window is opened from a user action, we must
+          // display an error message to inform the user that their action
+          // failed. Since the Google Meet window is temporary and the user can
+          // retry the action, we can just destroy the window so the user tries
+          // again.
+          onError: `warnAndDestroyWindow`,
+        });
 
         meetingUrlToOpen = await scrapeAndSaveMeetingUrl(window);
 

--- a/src/background/useWindowService/openHqWindow/configureAppActivateHandler.ts
+++ b/src/background/useWindowService/openHqWindow/configureAppActivateHandler.ts
@@ -16,6 +16,6 @@ export default (
   // Show the HQ window when user clicks on dock on Mac
   app.on(`activate`, () => {
     log.info(`App activate event received`);
-    openHqWindow(openHqWindowArgs);
+    openHqWindow({ ...openHqWindowArgs, show: true });
   });
 };

--- a/src/background/useWindowService/openHqWindow/getHqWindowBrowserOptions.ts
+++ b/src/background/useWindowService/openHqWindow/getHqWindowBrowserOptions.ts
@@ -2,7 +2,7 @@ import { BrowserWindowConstructorOptions, screen } from 'electron';
 
 import { getPreloadPath, isLinux } from '../../utils';
 
-export default (): BrowserWindowConstructorOptions => {
+export default (show: boolean): BrowserWindowConstructorOptions => {
   const primaryDisplay = screen.getPrimaryDisplay();
 
   return {
@@ -12,7 +12,7 @@ export default (): BrowserWindowConstructorOptions => {
     frame: !isLinux(),
     height: primaryDisplay.workArea.height,
     hiddenInMissionControl: false,
-    show: false,
+    show,
     skipTaskbar: false,
     webPreferences: { preload: getPreloadPath() },
     width: primaryDisplay.workArea.width,

--- a/src/background/useWindowService/openHqWindow/openHqWindow.ts
+++ b/src/background/useWindowService/openHqWindow/openHqWindow.ts
@@ -21,7 +21,15 @@ const openHqWindow: OpenHqWindow = async (args) => {
 
     // By the time we open the HQ window the user should be logged in, so
     // the home page will redirect the user to their company's HQ page
-    await loadUrl(`${getSiteUrl()}/`, window, state);
+    await loadUrl(`${getSiteUrl()}/`, window, state, {
+      // The HQ window is opened automatically when the app starts, and it
+      // defaults to being hidden. If it fails to load the URL, we don't want
+      // to display an error message to the user because they probably don't
+      // realize that the window was being loaded in the background. Instead,
+      // we can just destroy the HQ window so that it gets recreated when the
+      // user tries to open it again.
+      onError: `destroyWindow`,
+    });
 
     return window;
   });

--- a/src/background/useWindowService/openHqWindow/openHqWindow.ts
+++ b/src/background/useWindowService/openHqWindow/openHqWindow.ts
@@ -8,9 +8,9 @@ import { OpenHqWindow } from './types';
 import updateTray from './updateTray';
 
 const openHqWindow: OpenHqWindow = async (args) => {
-  const { state, trayService, windowOpenRequestHandler } = args;
+  const { show, state, trayService, windowOpenRequestHandler } = args;
 
-  const options = getHqWindowBrowserOptions();
+  const options = getHqWindowBrowserOptions(show);
 
   return openBrowserWindow(state, `hq`, options, async (window) => {
     window.webContents.setWindowOpenHandler(windowOpenRequestHandler);

--- a/src/background/useWindowService/openHqWindow/types.ts
+++ b/src/background/useWindowService/openHqWindow/types.ts
@@ -7,6 +7,7 @@ import { WindowOpenRequestHandler } from '../getWindowOpenRequestHandler';
 export type OpenHqWindow = (args: OpenHqWindowArgs) => Promise<BrowserWindow>;
 
 export interface OpenHqWindowArgs {
+  show: boolean;
   state: State;
   trayService: TrayService;
   windowOpenRequestHandler: WindowOpenRequestHandler;

--- a/src/background/useWindowService/openHqWindow/updateTray.ts
+++ b/src/background/useWindowService/openHqWindow/updateTray.ts
@@ -15,7 +15,7 @@ export default (
       type: `normal`,
       click: async (): Promise<void> => {
         log.info(`Received "Open Swivvel" click from tray menu`);
-        openHqWindow(openHqWindowArgs);
+        openHqWindow({ ...openHqWindowArgs, show: true });
       },
     },
   ]);

--- a/src/background/useWindowService/openLogInWindow/openLogInWindow.ts
+++ b/src/background/useWindowService/openLogInWindow/openLogInWindow.ts
@@ -27,7 +27,16 @@ const openLogInWindow: OpenLogInWindow = async (args) => {
     // page. We only open the log in window if the user is unauthenticated,
     // so navigating to the home page here should always result in the log in
     // page being displayed.
-    await loadUrl(`${getSiteUrl()}/`, window, state);
+    await loadUrl(`${getSiteUrl()}/`, window, state, {
+      // The log in window is opened automatically by the transparent window
+      // when the app first launches. If it fails to load the URL, we don't want
+      // to keep retrying because the user would see a blank window. Instead,
+      // just destroy the window. It will either be recreated when the user
+      // tries to open Swivvel from the tray, or the transparent window will
+      // have also failed to load and it will open the log in window when it
+      // gets recreated.
+      onError: `destroyWindow`,
+    });
 
     return window;
   });

--- a/src/background/useWindowService/openSettingsPageInHqWindow.ts
+++ b/src/background/useWindowService/openSettingsPageInHqWindow.ts
@@ -20,6 +20,7 @@ export default async ({
   windowOpenRequestHandler,
 }: Args): Promise<void> => {
   const hqWindow = await openHqWindow({
+    show: true,
     state,
     trayService,
     windowOpenRequestHandler,

--- a/src/background/useWindowService/openSettingsPageInHqWindow.ts
+++ b/src/background/useWindowService/openSettingsPageInHqWindow.ts
@@ -1,0 +1,38 @@
+import { State } from '../types';
+import { TrayService } from '../useTrayService';
+import { getSiteUrl, loadUrl } from '../utils';
+
+import { WindowOpenRequestHandler } from './getWindowOpenRequestHandler';
+import openHqWindow from './openHqWindow';
+
+interface Args {
+  state: State;
+  trayService: TrayService;
+  windowOpenRequestHandler: WindowOpenRequestHandler;
+}
+
+/**
+ * Load the settings page URL into the HQ window.
+ */
+export default async ({
+  state,
+  trayService,
+  windowOpenRequestHandler,
+}: Args): Promise<void> => {
+  const hqWindow = await openHqWindow({
+    state,
+    trayService,
+    windowOpenRequestHandler,
+  });
+
+  await loadUrl(
+    `${getSiteUrl()}/?p=/office/<companyId>/settings/users`,
+    hqWindow,
+    state,
+    // Since the settings page is opened from a user action, we must display
+    // an error message to inform the user that their action failed. We
+    // destroy the window so that it gets recreated when the user tries to
+    // open it again.
+    { onError: `warnAndDestroyWindow` }
+  );
+};

--- a/src/background/useWindowService/openSetupWindow/openSetupWindow.ts
+++ b/src/background/useWindowService/openSetupWindow/openSetupWindow.ts
@@ -19,7 +19,16 @@ const openSetupWindow: OpenSetupWindow = async (args) => {
     configureAppActivateHandler(openSetupWindow, args);
     updateTray(openSetupWindow, args, trayService);
 
-    await loadUrl(`${getSiteUrl()}/setup`, window, state);
+    await loadUrl(`${getSiteUrl()}/setup`, window, state, {
+      // The setup window is opened automatically by the transparent window
+      // when the app first launches. If it fails to load the URL, we don't want
+      // to keep retrying because the user would see a blank window. Instead,
+      // just destroy the window. It will either be recreated when the user
+      // tries to open Swivvel from the tray, or the transparent window will
+      // have also failed to load and it will open the log in window when it
+      // gets recreated.
+      onError: `destroyWindow`,
+    });
 
     return window;
   });

--- a/src/background/useWindowService/openTransparentWindow/configureCloseHandler.ts
+++ b/src/background/useWindowService/openTransparentWindow/configureCloseHandler.ts
@@ -15,7 +15,6 @@ export default (transparentWindow: BrowserWindow, state: State): void => {
     } else if (!state.allowQuit) {
       log.info(`allowQuit=false, preventing transparent window from closing`);
       event.preventDefault();
-      transparentWindow.hide();
     } else {
       log.info(`Closing transparent window...`);
     }

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -32,7 +32,7 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
       // The transparent window is core to the application because it's
       // responsible for opening all of the other windows and displaying the
       // audio room. Retry loading the URL indefinitely if it fails.
-      retry: true,
+      onError: `retry`,
     });
 
     return window;

--- a/src/background/useWindowService/openTransparentWindow/pollForMouseEvents.ts
+++ b/src/background/useWindowService/openTransparentWindow/pollForMouseEvents.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, screen } from 'electron';
+import log from 'electron-log';
 
 /**
  * Support mouse events on the transparent notification window.
@@ -18,6 +19,8 @@ import { BrowserWindow, screen } from 'electron';
  */
 export default (transparentWindow: BrowserWindow): void => {
   transparentWindow.setIgnoreMouseEvents(true);
+
+  let mouseIsOverTransparentPrevious: boolean | null = null;
 
   const interval = setInterval(async () => {
     if (transparentWindow.isDestroyed()) {
@@ -55,6 +58,14 @@ export default (transparentWindow: BrowserWindow): void => {
       }
 
       transparentWindow.setIgnoreMouseEvents(mouseIsOverTransparent);
+
+      if (mouseIsOverTransparent !== mouseIsOverTransparentPrevious) {
+        log.info(
+          `Mouse is over transparent: ${mouseIsOverTransparentPrevious} -> ${mouseIsOverTransparent}`
+        );
+      }
+
+      mouseIsOverTransparentPrevious = mouseIsOverTransparent;
     }
   }, 50);
 };

--- a/src/background/useWindowService/useWindowService.ts
+++ b/src/background/useWindowService/useWindowService.ts
@@ -28,7 +28,12 @@ export default (state: State, trayService: TrayService): WindowService => {
       });
     },
     onHqPageRequested: () => {
-      openHqWindow({ state, trayService, windowOpenRequestHandler });
+      openHqWindow({
+        show: false,
+        state,
+        trayService,
+        windowOpenRequestHandler,
+      });
     },
     onLogInPageRequested: () => {
       openLogInWindow({ state, trayService, windowOpenRequestHandler });

--- a/src/background/useWindowService/useWindowService.ts
+++ b/src/background/useWindowService/useWindowService.ts
@@ -3,12 +3,12 @@ import log from 'electron-log';
 
 import { State } from '../types';
 import { TrayService } from '../useTrayService';
-import { getSiteUrl, loadUrl } from '../utils';
 
 import getWindowOpenRequestHandler from './getWindowOpenRequestHandler';
 import openGoogleMeetWindow from './openGoogleMeetWindow';
 import openHqWindow from './openHqWindow';
 import openLogInWindow from './openLogInWindow';
+import openSettingsPageInHqWindow from './openSettingsPageInHqWindow';
 import openSetupWindow from './openSetupWindow';
 import openTransparentWindow from './openTransparentWindow';
 import { WindowService } from './types';
@@ -37,17 +37,11 @@ export default (state: State, trayService: TrayService): WindowService => {
       openSetupWindow({ state, trayService, windowOpenRequestHandler });
     },
     onSettingsPageRequested: async () => {
-      const hqWindow = await openHqWindow({
+      openSettingsPageInHqWindow({
         state,
         trayService,
         windowOpenRequestHandler,
       });
-
-      await loadUrl(
-        `${getSiteUrl()}/?p=/office/<companyId>/settings/users`,
-        hqWindow,
-        state
-      );
     },
   });
 

--- a/src/background/utils/loadUrl.ts
+++ b/src/background/utils/loadUrl.ts
@@ -33,7 +33,7 @@ const loadUrl = async (
     await browserWindow.loadURL(url);
   } catch (err) {
     log.error(`Failed to load URL into window '${windowName}': ${urlNoParams}`);
-    log.info(`onError=${options.onError}}`);
+    log.info(`onError=${options.onError}`);
 
     if (browserWindow.isDestroyed()) {
       log.info(`Skipping error handling: window '${windowName}' is destroyed`);

--- a/src/background/utils/loadUrl.ts
+++ b/src/background/utils/loadUrl.ts
@@ -10,11 +10,17 @@ import removeQueryParams from './removeQueryParams';
 import showErrorMessage from './showErrorMessage';
 import sleep from './sleep';
 
+type OnError =
+  | `retry`
+  | `destroyWindow`
+  | `warnAndDestroyWindow`
+  | `warnAndQuitApp`;
+
 const loadUrl = async (
   url: string,
   browserWindow: BrowserWindow,
   state: State,
-  options?: { retry: boolean },
+  options: { onError: OnError },
   retryState?: { retryCount: number; retryCurrentBackoffMs: number }
 ): Promise<void> => {
   const urlNoParams = removeQueryParams(url);
@@ -27,77 +33,102 @@ const loadUrl = async (
     await browserWindow.loadURL(url);
   } catch (err) {
     log.error(`Failed to load URL into window '${windowName}': ${urlNoParams}`);
+    log.info(`onError=${options.onError}}`);
 
-    if (options?.retry) {
-      if (browserWindow.isDestroyed()) {
-        log.info(`Skipping retry: window '${windowName}' is destroyed`);
-      } else {
-        let retryCount = retryState?.retryCount || 0;
-        let retryCurrentBackoffMs =
-          retryState?.retryCurrentBackoffMs || ms(`1 second`);
-
-        // It is common for the URL to have temporary errors, such as when a
-        // user's computer wakes up after being suspended. Perform the retries
-        // in a tight loop in the beginning so that the window loads more
-        // quickly if the error is temporary, then back off to a slower retry
-        // rate to avoid putting too much load on our servers or the user's
-        // system.
-        retryCount += 1;
-        retryCurrentBackoffMs =
-          retryCount > 60 ? ms(`1 minute`) : ms(`5 seconds`);
-
-        log.info(
-          `Retrying load URL in ${
-            retryCurrentBackoffMs / 1000
-          } seconds (retryCount=${retryCount})...`
-        );
-
-        await sleep(retryCurrentBackoffMs);
-        await loadUrl(
-          url,
-          browserWindow,
-          state,
-          { retry: true },
-          {
-            retryCount,
-            retryCurrentBackoffMs,
-          }
-        );
-
-        return;
-      }
-    }
-
-    // The user might have quit the app in the middle of the page load, in
-    // which case we don't want to show the error message. Note that `quitApp`
-    // sets `state.allowQuit`, so we have to read the value before we call
-    // `quitApp`.
-    //
-    // The user might also have already completed authentication, at which point
-    // it doesn't matter if the log in window encounters an error while loading
-    // a URL.
-    const isFatal =
-      !state.allowQuit && (windowName !== `logIn` || !state.logInFlowCompleted);
-
-    log.info(`Window name is ${windowName}`);
-    log.info(`State allowQuit is ${state.allowQuit}`);
-    log.info(`State logInFlowCompleted is ${state.logInFlowCompleted}`);
-
-    if (!isFatal) {
-      log.info(`Ignoring error because it is not fatal`);
+    if (browserWindow.isDestroyed()) {
+      log.info(`Skipping error handling: window '${windowName}' is destroyed`);
       return;
     }
 
-    log.error(`Error is fatal, quitting app and showing error message...`);
+    if (options.onError === `retry`) {
+      let retryCount = retryState?.retryCount || 0;
+      let retryCurrentBackoffMs =
+        retryState?.retryCurrentBackoffMs || ms(`1 second`);
 
-    // Eventually we may want to have better error handling if a URL fails to
-    // load, but this is usually a fatal error so for now we're just killing
-    // the app so that it doesn't exist in a broken state
-    quitApp(state);
+      // It is common for the URL to have temporary errors, such as when a
+      // user's computer wakes up after being suspended. Perform the retries
+      // in a tight loop in the beginning so that the window loads more
+      // quickly if the error is temporary, then back off to a slower retry
+      // rate to avoid putting too much load on our servers or the user's
+      // system.
+      retryCount += 1;
+      retryCurrentBackoffMs =
+        retryCount > 60 ? ms(`1 minute`) : ms(`5 seconds`);
 
-    showErrorMessage({
-      description: `Unable to load page:\n${urlNoParams}\n\nCheck your internet connection and try again.`,
-    });
+      log.info(
+        `Retrying load URL in ${
+          retryCurrentBackoffMs / 1000
+        } seconds (retryCount=${retryCount})...`
+      );
+
+      await sleep(retryCurrentBackoffMs);
+      await loadUrl(url, browserWindow, state, options, {
+        retryCount,
+        retryCurrentBackoffMs,
+      });
+
+      return;
+    }
+
+    if (options.onError === `destroyWindow`) {
+      log.info(`Destroy window '${windowName}'...`);
+      browserWindow.destroy();
+      if (windowName) {
+        state.windows[windowName] = null;
+      }
+      return;
+    }
+
+    if (options.onError === `warnAndDestroyWindow`) {
+      log.info(`Warning and closing window '${windowName}'...`);
+      browserWindow.destroy();
+      if (windowName) {
+        state.windows[windowName] = null;
+      }
+      showErrorMessage({
+        description: `Unable to load page:\n${urlNoParams}\n\nCheck your internet connection and try again.`,
+      });
+      return;
+    }
+
+    if (options.onError === `warnAndQuitApp`) {
+      // The user might have quit the app in the middle of the page load, in
+      // which case we don't want to show the error message. Note that `quitApp`
+      // sets `state.allowQuit`, so we have to read the value before we call
+      // `quitApp`.
+      //
+      // The user might also have already completed authentication, at which
+      // point it doesn't matter if the log in window encounters an error while
+      // loading a URL.
+      const isFatal =
+        !state.allowQuit &&
+        (windowName !== `logIn` || !state.logInFlowCompleted);
+
+      log.info(`windowName=${windowName}`);
+      log.info(`state.allowQuit=${state.allowQuit}`);
+      log.info(`state.logInFlowCompleted=${state.logInFlowCompleted}`);
+
+      if (!isFatal) {
+        log.info(`Ignoring error because it is not fatal`);
+        return;
+      }
+
+      log.error(`Error is fatal, quitting app and showing error message...`);
+
+      // Eventually we may want to have better error handling if a URL fails to
+      // load, but this is usually a fatal error so for now we're just killing
+      // the app so that it doesn't exist in a broken state
+      quitApp(state);
+
+      showErrorMessage({
+        description: `Unable to load page:\n${urlNoParams}\n\nCheck your internet connection and try again.`,
+      });
+
+      return;
+    }
+
+    const exhaustiveCheck: never = options.onError;
+    return exhaustiveCheck;
   }
 };
 


### PR DESCRIPTION
## The Problem

Whenever a window fails to load a URL, we currently show an error message and quit the entire app. We implemented it this way because this was the easiest way make sure that the app didn't end up in a broken state that the user couldn't recover from.

However, we have now encountered a number of situations where quitting the app is particularly disruptive and confusing to users. For example, now that we destroy all windows when a user locks their screen, it is common for the HQ window to fail to load the URL on unlock because the internet connection hasn't been established yet. In this situation, the user currently sees a scary error message and the app quits.

## The Solution

Add a new `onError` option to the `loadUrl()` function that allows us to decide exactly how we want errors to be handled for each window.

## Other Changes

- Remove log line in idle time poller when transparent window is destroyed. We could get in a state where this would print a log line every second for hours.
- Add logging when transparent-pixel mouse-over detection changes state. This will help debug an issue that someone on Ubuntu 22.04 encountered where the transparent window was always capturing mouse events.
- Prevent the transparent window from ever being hidden. It was possible to accidentally hide the transparent window using a keyboard shortcut.
- Fix a bug where the app would quit if the transparent window failed to load a URL after it was destroyed

## Testing

- [x] Simulate login OAuth callback URL failing, app shows error message and quits
- [x] Simulate settings page failing, app warns and destroys the window
- [x] Simulate HQ window failing, app silently destroys the window
- [x] Transparent window is no longer hidden when using "close window" keyboard shortcut