### PR TITLE
Reuse fullscreen bounds logic for HQ window positioning

### DIFF
--- a/src/background/useWindowService/openHqWindow/getHqWindowBrowserOptions.ts
+++ b/src/background/useWindowService/openHqWindow/getHqWindowBrowserOptions.ts
@@ -1,15 +1,30 @@
 import { BrowserWindowConstructorOptions, screen } from 'electron';
 
-import { getPreloadPath } from '../../utils';
+import { getPreloadPath, isLinux } from '../../utils';
 
 export default (show: boolean): BrowserWindowConstructorOptions => {
   const primaryDisplay = screen.getPrimaryDisplay();
 
+  let height: number;
+  let width: number;
+
+  if (isLinux()) {
+    // There's a bug on Ubuntu where the window title bar is transparent if
+    // the window is sized to take up the entire work area, so make the window
+    // large enough that it will probably fit on most screens.
+    height = Math.min(primaryDisplay.workArea.height, 1000);
+    width = Math.min(primaryDisplay.workArea.width, 1400);
+  } else {
+    height = primaryDisplay.workArea.height;
+    width = primaryDisplay.workArea.width;
+  }
+
   return {
     backgroundColor: `#ffffff`,
-    height: Math.min(primaryDisplay.workArea.height, 800),
+    center: true,
+    height,
     show,
     webPreferences: { preload: getPreloadPath() },
-    width: Math.min(primaryDisplay.workArea.width, 1400),
+    width,
   };
 };

--- a/src/background/useWindowService/openHqWindow/getHqWindowBrowserOptions.ts
+++ b/src/background/useWindowService/openHqWindow/getHqWindowBrowserOptions.ts
@@ -1,23 +1,9 @@
-import { BrowserWindowConstructorOptions, screen } from 'electron';
+import { BrowserWindowConstructorOptions } from 'electron';
 
-import { getPreloadPath, isLinux } from '../../utils';
+import { getFullscreenBounds, getPreloadPath } from '../../utils';
 
 export default (show: boolean): BrowserWindowConstructorOptions => {
-  const primaryDisplay = screen.getPrimaryDisplay();
-
-  let height: number;
-  let width: number;
-
-  if (isLinux()) {
-    // There's a bug on Ubuntu where the window title bar is transparent if
-    // the window is sized to take up the entire work area, so make the window
-    // large enough that it will probably fit on most screens.
-    height = Math.min(primaryDisplay.workArea.height, 1000);
-    width = Math.min(primaryDisplay.workArea.width, 1400);
-  } else {
-    height = primaryDisplay.workArea.height;
-    width = primaryDisplay.workArea.width;
-  }
+  const { height, width, x, y } = getFullscreenBounds();
 
   return {
     backgroundColor: `#ffffff`,
@@ -26,5 +12,7 @@ export default (show: boolean): BrowserWindowConstructorOptions => {
     show,
     webPreferences: { preload: getPreloadPath() },
     width,
+    x,
+    y,
   };
 };

--- a/src/background/useWindowService/openHqWindow/getHqWindowBrowserOptions.ts
+++ b/src/background/useWindowService/openHqWindow/getHqWindowBrowserOptions.ts
@@ -1,22 +1,15 @@
 import { BrowserWindowConstructorOptions, screen } from 'electron';
 
-import { getPreloadPath, isLinux } from '../../utils';
+import { getPreloadPath } from '../../utils';
 
 export default (show: boolean): BrowserWindowConstructorOptions => {
   const primaryDisplay = screen.getPrimaryDisplay();
 
   return {
-    autoHideMenuBar: isLinux(),
     backgroundColor: `#ffffff`,
-    focusable: true,
-    frame: !isLinux(),
-    height: primaryDisplay.workArea.height,
-    hiddenInMissionControl: false,
+    height: Math.min(primaryDisplay.workArea.height, 800),
     show,
-    skipTaskbar: false,
     webPreferences: { preload: getPreloadPath() },
-    width: primaryDisplay.workArea.width,
-    x: primaryDisplay.workArea.x,
-    y: primaryDisplay.workArea.y,
+    width: Math.min(primaryDisplay.workArea.width, 1400),
   };
 };

--- a/src/background/useWindowService/openTransparentWindow/getTransparentBrowserWindowOptions.ts
+++ b/src/background/useWindowService/openTransparentWindow/getTransparentBrowserWindowOptions.ts
@@ -1,14 +1,12 @@
 import { BrowserWindowConstructorOptions, screen } from 'electron';
 import log from 'electron-log';
 
-import { getPreloadPath, isLinux } from '../../utils';
-
-import { getBounds } from './utils';
+import { getFullscreenBounds, getPreloadPath, isLinux } from '../../utils';
 
 export default (): BrowserWindowConstructorOptions => {
   log.info(`All displays: ${JSON.stringify(screen.getAllDisplays())}`);
 
-  const bounds = getBounds();
+  const bounds = getFullscreenBounds();
   const { height, width, x, y } = bounds;
 
   log.info(`Setting transparent window bounds: ${JSON.stringify(bounds)}`);

--- a/src/background/useWindowService/openTransparentWindow/getTransparentBrowserWindowOptions.ts
+++ b/src/background/useWindowService/openTransparentWindow/getTransparentBrowserWindowOptions.ts
@@ -30,6 +30,7 @@ export default (): BrowserWindowConstructorOptions => {
     minimizable: false,
     resizable: false,
     roundedCorners: false,
+    show: false,
     skipTaskbar: true,
     transparent: true,
     webPreferences: { preload: getPreloadPath() },

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -14,8 +14,9 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
   const options = getTransparentBrowserWindowOptions();
 
   return openBrowserWindow(state, `transparent`, options, async (window) => {
-    // Prevent the transparent window from getting focus when it loads
-    window.blur();
+    // Show the window but don't focus it because it would be confusing to users
+    // if an invisible window took focus.
+    window.showInactive();
 
     // Transparent windows don't work on Linux without some hacks
     // like this short delay

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -14,6 +14,8 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
   const options = getTransparentBrowserWindowOptions();
 
   return openBrowserWindow(state, `transparent`, options, async (window) => {
+    window.blur();
+
     // Transparent windows don't work on Linux without some hacks
     // like this short delay
     // See: https://github.com/electron/electron/issues/15947

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -14,6 +14,7 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
   const options = getTransparentBrowserWindowOptions();
 
   return openBrowserWindow(state, `transparent`, options, async (window) => {
+    // Prevent the transparent window from getting focus when it loads
     window.blur();
 
     // Transparent windows don't work on Linux without some hacks

--- a/src/background/useWindowService/openTransparentWindow/resizeOnDisplayChange.ts
+++ b/src/background/useWindowService/openTransparentWindow/resizeOnDisplayChange.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow, screen } from 'electron';
 import log from 'electron-log';
 
-import { getBounds } from './utils';
+import { getFullscreenBounds } from '../../utils';
 
 /**
  * Make sure the transparent window is always resized to fit the primary
@@ -17,7 +17,7 @@ export default (window: BrowserWindow): void => {
       return;
     }
 
-    const bounds = getBounds();
+    const bounds = getFullscreenBounds();
     const { height, width, x, y } = bounds;
 
     log.info(

--- a/src/background/useWindowService/openTransparentWindow/utils/index.ts
+++ b/src/background/useWindowService/openTransparentWindow/utils/index.ts
@@ -1,3 +1,0 @@
-import getBounds from './getBounds';
-
-export { getBounds };

--- a/src/background/utils/getFullscreenBounds.ts
+++ b/src/background/utils/getFullscreenBounds.ts
@@ -1,6 +1,6 @@
 import { screen } from 'electron';
 
-import { isLinux } from '../../../utils';
+import isLinux from './isLinux';
 
 // We are unlikely to have any Linux users, so we're optimizing for Ubuntu for
 // now. The top bar may be different heights on other Linux distros, but we can

--- a/src/background/utils/index.ts
+++ b/src/background/utils/index.ts
@@ -1,4 +1,5 @@
 import getBrowserWindowName from './getBrowserWindowName';
+import getFullscreenBounds from './getFullscreenBounds';
 import getLogoTemplatePath from './getLogoTemplatePath';
 import getPreloadPath from './getPreloadPath';
 import getShareableMediaSources from './getShareableMediaSources';
@@ -16,6 +17,7 @@ import sleep from './sleep';
 
 export {
   getBrowserWindowName,
+  getFullscreenBounds,
   getLogoTemplatePath,
   getPreloadPath,
   getShareableMediaSources,


### PR DESCRIPTION
## The Problem

When the HQ window is opened, we want to position it to take up the full screen so that users can see as much of the page as possible. We're currently doing that by setting the size & position to be the same as the `workArea` value that we get from the Electron `screen` module.

However, the `workArea` value is sometimes incorrect. On Ubuntu 23.04, this caused the title bar of the HQ window to be transparent when it opened, presumably because we were settings the window to be larger than the available screen area. We previously worked around this by setting `frame: false` for Linux, but that made it impossible to drag the window around or close/minimize it using the window title bar buttons.

## The Solution

In commit b6b6d4f941a9fa82098b884e83fd90af54716249, we created a `getBounds()` function for the transparent window that works around bugs with the work area size.

This commit moves the `getBounds()` function to a common `utils/` directory and renames it to `getFullscreenBounds()`, and then uses it when determining the size and position of the HQ window.

Reusing the `getFullscreenBounds()` function will also help ensure that any future OS-specific workarounds will be applied everywhere where we are opening a fullscreen window.

## Other Changes

Stop the transparent window from getting focus when it opens. It was confusing when the app launched and your current window lost focus without it being clear what new window gained focus.