### PR TITLE
Hide transparent window in screenshots

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+<!--
+  PR title conventions:
+
+  Max length: 63 characters (enforced by a GitHub action)
+
+  Use imperative mood (see https://cbea.ms/git-commit/#imperative). In other
+  words, a PR title should always be able to complete the following sentence:
+  "If applied, this PR will __your subject line here__". For example: "Refactor
+  subsystem X for readability" completes the sentence "If applied, this PR
+  will __refactor subsystem X for readability__".
+-->
+
+## The Problem
+
+<!--
+  Describe the product or technical problem you are solving with this PR.
+  Provide as much business context as possible. This problem description should
+  be able to stand on its own without linking out to other resources, but feel
+  free to include links to provide helpful context.
+-->
+
+## The Solution
+
+<!--
+  Describe the solution to the problem. Explain why you're solving the problem
+  this way. Provide any context that isn't already included in code comments.
+  The goal is for someone reading this PR to be able to understand your
+  decisions without having to talk to you.
+-->
+
+## Other Changes
+
+<!--
+  If you snuck other changes into this PR, make sure to document the problem
+  and solution here.
+-->
+
+## Testing
+
+<!--
+  Create a checklist of what you did to test your code.
+-->

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,17 @@
+name: Check PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  check_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: deepakputhraya/action-pr-title@master
+        with:
+          max_length: 63

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -15,6 +15,7 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
 
   return openBrowserWindow(state, `transparent`, options, async (window) => {
     // Prevent the transparent window from appearing in screenshots
+    // See: https://www.electronjs.org/docs/latest/api/browser-window#winsetcontentprotectionenable-macos-windows
     window.setContentProtection(true);
 
     // Transparent windows don't work on Linux without some hacks

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -21,6 +21,7 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
       await sleep(1000);
     }
 
+    window.setContentProtection(true);
     window.webContents.setWindowOpenHandler(windowOpenRequestHandler);
 
     showOnAllWorkspaces(window);

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -14,6 +14,9 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
   const options = getTransparentBrowserWindowOptions();
 
   return openBrowserWindow(state, `transparent`, options, async (window) => {
+    // Prevent the transparent window from appearing in screenshots
+    window.setContentProtection(true);
+
     // Transparent windows don't work on Linux without some hacks
     // like this short delay
     // See: https://github.com/electron/electron/issues/15947
@@ -21,7 +24,6 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
       await sleep(1000);
     }
 
-    window.setContentProtection(true);
     window.webContents.setWindowOpenHandler(windowOpenRequestHandler);
 
     showOnAllWorkspaces(window);


### PR DESCRIPTION
## The Problem

The Swivvel audio room widget is always on top of all windows and can be minimized but not closed completely. This makes it hard to take screenshots without the widget in them.

## The Solution

Use the `window.setContentProtection(true)` command to prevent the transparent window from appearing in screenshots. According to the [Electron docs](https://www.electronjs.org/docs/latest/api/browser-window#winsetcontentprotectionenable-macos-windows):

> Prevents the window contents from being captured by other apps.
>
> On macOS it sets the NSWindow's sharingType to NSWindowSharingNone. On Windows it calls SetWindowDisplayAffinity with WDA_EXCLUDEFROMCAPTURE. For Windows 10 version 2004 and up the window will be removed from capture entirely, older Windows versions behave as if WDA_MONITOR is applied capturing a black window.

## Other Changes

- Add a PR template to ensure consistency in PR titles and descriptions
- Add a GitHub action to enforce PR title length