### PR TITLE
Fix auto updating on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
       }
     },
     "win": {
+      "artifactName": "${productName}-win.${ext}",
       "icon": "build/icon.ico"
     },
     "linux": {

--- a/src/background/utils/quitApp.ts
+++ b/src/background/utils/quitApp.ts
@@ -1,5 +1,6 @@
-import { app, autoUpdater } from 'electron';
+import { app } from 'electron';
 import log from 'electron-log';
+import { autoUpdater } from 'electron-updater';
 
 import { State } from '../types';
 


### PR DESCRIPTION
## The Problem

Auto-updating was not working on windows. When the update was run, it would uninstall the previous version of the app without replacing it. We could tell this because `C:\Users\ericropiak\AppData\Local\Programs\swivvel\` was empty after the "update" command was run.

## The Solution

Cedric stumbled across this PR, which suggested that the artifact name has to be different from the product name. https://github.com/electron-userland/electron-builder/issues/7184

## Other Changes

Update them import of auto updater in one file to match the imports elsewhere. This ensures the same instance is being used across our entire app

## Testing

Tested in a windows VM. Verified that running subsequent installs would first uninstall the previous version and then install the new version, without breaking any desktop shortcuts