### PR TITLE
Fix bug where transparent window not always on top on Linux

### DIFF
--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -22,6 +22,10 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
     // if an invisible window took focus.
     window.showInactive();
 
+    // On Linux, calling `showInactive()` causes the window to no longer appear
+    // on top, so we have to explicitly re-enable the always-on-top setting.
+    window.setAlwaysOnTop(true);
+
     // Transparent windows don't work on Linux without some hacks
     // like this short delay
     // See: https://github.com/electron/electron/issues/15947


### PR DESCRIPTION
## The Problem

In commit 08a3070ffd4ad143cb823e56fef749a3d89e3f29, we made a change to stop the transparent window from getting focus when it opens. This broke the always-on-top behavior on Linux.

## The Solution

Call `window.setAlwaysOnTop(true)` after showing the transparent window to make sure that it is properly configured to be always on top.
