### PR TITLE
Report errors to Sentry; add manual error reporting tray item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "swivvel",
       "version": "1.2.20",
       "dependencies": {
+        "@sentry/electron": "^4.13.0",
         "electron-log": "^4.4.8",
         "electron-serve": "^1.1.0",
         "electron-store": "^8.1.0",
@@ -659,6 +660,115 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.73.0.tgz",
+      "integrity": "sha512-ig3WL/Nqp8nRQ52P205NaypGKNfIl/G+cIqge9xPW6zfRb5kJdM1YParw9GSJ1SPjEZBkBORGAML0on5H2FILw==",
+      "dependencies": {
+        "@sentry/core": "7.73.0",
+        "@sentry/types": "7.73.0",
+        "@sentry/utils": "7.73.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "7.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.73.0.tgz",
+      "integrity": "sha512-e301hUixcJ5+HNKCJwajFF5smF4opXEFSclyWsJuFNufv5J/1C1SDhbwG2JjBt5zzdSoKWJKT1ewR6vpICyoDw==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.73.0",
+        "@sentry/core": "7.73.0",
+        "@sentry/replay": "7.73.0",
+        "@sentry/types": "7.73.0",
+        "@sentry/utils": "7.73.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.73.0.tgz",
+      "integrity": "sha512-9FEz4Gq848LOgVN2OxJGYuQqxv7cIVw69VlAzWHEm3njt8mjvlTq+7UiFsGRo84+59V2FQuHxzA7vVjl90WfSg==",
+      "dependencies": {
+        "@sentry/types": "7.73.0",
+        "@sentry/utils": "7.73.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/electron": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-4.13.0.tgz",
+      "integrity": "sha512-rVBMGX8WHc/DOeqlWZnl/EFxBFJgI1Y6nJi7u1HWRcAadTFKB1fmbVLbhVreIsQVP0Mc2HjP3Vyy6UXZ9+Mq5A==",
+      "dependencies": {
+        "@sentry/browser": "7.73.0",
+        "@sentry/core": "7.73.0",
+        "@sentry/node": "7.73.0",
+        "@sentry/types": "7.73.0",
+        "@sentry/utils": "7.73.0",
+        "deepmerge": "4.3.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.73.0.tgz",
+      "integrity": "sha512-i50bRfmgkRRx0XXUbg9jGD/RuznDJxJXc4rBILhoJuhl+BjRIaoXA3ayplfJn8JLZxsNh75uJaCq4IUK70SORw==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.73.0",
+        "@sentry/core": "7.73.0",
+        "@sentry/types": "7.73.0",
+        "@sentry/utils": "7.73.0",
+        "cookie": "^0.5.0",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "7.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.73.0.tgz",
+      "integrity": "sha512-a8IC9SowBisLYD2IdLkXzx7gN4iVwHDJhQvLp2B8ARs1PyPjJ7gCxSMHeGrYp94V0gOXtorNYkrxvuX8ayPROA==",
+      "dependencies": {
+        "@sentry/core": "7.73.0",
+        "@sentry/types": "7.73.0",
+        "@sentry/utils": "7.73.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.73.0.tgz",
+      "integrity": "sha512-/v8++bly8jW7r4cP2wswYiiVpn7eLLcqwnfPUMeCQze4zj3F3nTRIKc9BGHzU0V+fhHa3RwRC2ksqTGq1oJMDg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.73.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.73.0.tgz",
+      "integrity": "sha512-h3ZK/qpf4k76FhJV9uiSbvMz3V/0Ovy94C+5/9UgPMVCJXFmVsdw8n/dwANJ7LupVPfYP23xFGgebDMFlK1/2w==",
+      "dependencies": {
+        "@sentry/types": "7.73.0",
+        "tslib": "^2.4.1 || ^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -1084,7 +1194,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -1976,6 +2085,14 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2074,6 +2191,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
@@ -3861,7 +3986,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -4858,6 +4982,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -6446,6 +6575,11 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "check": "npx npm-check --skip-unused",
     "compile": "rm -rf compiled && mkdir compiled && cp src/*.png compiled && tsc",
-    "dev": "electron compiled/background/background.js",
+    "dev": "electron .",
     "dist": "npm run compile && electron-builder",
     "lint": "eslint .",
     "types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "watch": "mkdir -p compiled && cp src/*.png compiled && tsc --watch"
   },
   "dependencies": {
+    "@sentry/electron": "^4.13.0",
     "electron-log": "^4.4.8",
     "electron-serve": "^1.1.0",
     "electron-store": "^8.1.0",

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -15,14 +15,16 @@ import { State } from './types';
 import useTrayService from './useTrayService';
 import useWindowService from './useWindowService';
 
-// Must be called before Sentry is configured
+// Call as early as possible since this changes the directory path where
+// Electron stores everything related to the app
 setUserDataPath();
-
-// Call as early as possible to ensure that all exceptions are logged
-configureSentry();
 
 const run = async (): Promise<void> => {
   log.info(`App v=${app.getVersion()} starting...`);
+  log.info(`User Data: ${app.getPath(`userData`)}`);
+
+  // Call at the beginning so that all exceptions are captured
+  configureSentry();
 
   const state: State = {
     allowQuit: false,

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -5,13 +5,21 @@ import configureApp from './configureApp';
 import configureAppQuitHandling from './configureAppQuitHandling';
 import configureAutoUpdates from './configureAutoUpdates';
 import configureIpcHandlers from './configureIpcHandlers';
+import configureSentry from './configureSentry';
 import getDeepLinkHandler from './getDeepLinkHandler';
 import handlePowerMonitorStateChanges from './handlePowerMonitorStateChanges';
 import listenForDeepLinks from './listenForDeepLinks';
 import pollForIdleTime from './pollForIdleTime';
+import setUserDataPath from './setUserDataPath';
 import { State } from './types';
 import useTrayService from './useTrayService';
 import useWindowService from './useWindowService';
+
+// Must be called before Sentry is configured
+setUserDataPath();
+
+// Call as early as possible to ensure that all exceptions are logged
+configureSentry();
 
 const run = async (): Promise<void> => {
   log.info(`App v=${app.getVersion()} starting...`);

--- a/src/background/configureApp.ts
+++ b/src/background/configureApp.ts
@@ -1,22 +1,13 @@
 import { app } from 'electron';
 import log from 'electron-log';
 
-import { isLinux, isProduction } from './utils';
+import { isLinux } from './utils';
 
 /**
  * Configure the global app settings.
  */
 export default (): void => {
   log.info(`Configuring app...`);
-
-  // Electron stores everything related to the app (cache, local storage,
-  // databases, logs, etc.) in a directory in the user's home directory.
-  // Prevent dev from colliding with prod by adding a suffix.
-  if (!isProduction()) {
-    app.setPath(`userData`, `${app.getPath(`userData`)}-development`);
-  }
-
-  log.info(`User Data: ${app.getPath(`userData`)}`);
 
   // Transparent windows don't work in Linux without these settings
   // See: https://github.com/electron/electron/issues/15947

--- a/src/background/configureApp.ts
+++ b/src/background/configureApp.ts
@@ -9,9 +9,11 @@ import { isLinux } from './utils';
 export default (): void => {
   log.info(`Configuring app...`);
 
-  // Transparent windows don't work in Linux without these settings
-  // See: https://github.com/electron/electron/issues/15947
   if (isLinux()) {
+    log.info(`Setting Linux configuration options...`);
+
+    // Transparent windows don't work in Linux without these settings
+    // See: https://github.com/electron/electron/issues/15947
     app.commandLine.appendSwitch(`enable-transparent-visuals`);
     app.commandLine.appendSwitch(`disable-gpu`);
     app.disableHardwareAcceleration();

--- a/src/background/configureSentry.ts
+++ b/src/background/configureSentry.ts
@@ -1,4 +1,7 @@
+import fs from 'fs';
+
 import * as Sentry from '@sentry/electron/main';
+import log from 'electron-log';
 
 import { isProduction } from './utils';
 
@@ -10,4 +13,17 @@ export default (): void => {
   });
 
   Sentry.setTag(`swivvel.service`, `electron`);
+
+  // Attach the log files to every Sentry alert
+  Sentry.addGlobalEventProcessor((event, hint) => {
+    log.info(`Sentry addGlobalEventProcessor called; attaching log files`);
+
+    const logFilePath = log.transports.file.getFile().path;
+
+    log.info(`Reading log file: ${logFilePath}`);
+    const logFileContents = fs.readFileSync(logFilePath).toString();
+
+    hint.attachments = [{ filename: `main.log`, data: logFileContents }];
+    return event;
+  });
 };

--- a/src/background/configureSentry.ts
+++ b/src/background/configureSentry.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/electron/main';
+
+import { isProduction } from './utils';
+
+export default (): void => {
+  Sentry.init({
+    dsn: isProduction()
+      ? `https://2dc312dd96e84f3ca06fa0e5e3f96c5e@o4504796289433600.ingest.sentry.io/4504796469657600`
+      : `https://c63ffcba511c4cdebd5365c4cb2990f6@o4504796289433600.ingest.sentry.io/4504796459171840`,
+  });
+
+  Sentry.setTag(`swivvel.service`, `electron`);
+};

--- a/src/background/setUserDataPath.ts
+++ b/src/background/setUserDataPath.ts
@@ -10,11 +10,12 @@ export default (): void => {
     // Electron stores everything related to the app (cache, local storage,
     // databases, logs, etc.) in a directory in the user's home directory.
     // Prevent dev from colliding with prod by adding a suffix.
-    app.setPath(`userData`, `${app.getPath(`userData`)}-development`);
+    const userDataPath = `${app.getPath(`userData`)}-development`;
+    app.setPath(`userData`, userDataPath);
 
     // Make sure the main logger writes to the new user data path
     log.transports.file.resolvePath = (): string => {
-      return path.join(app.getPath(`userData`), `logs`, `main.log`);
+      return path.join(userDataPath, `logs`, `main.log`);
     };
   }
 };

--- a/src/background/setUserDataPath.ts
+++ b/src/background/setUserDataPath.ts
@@ -1,0 +1,15 @@
+import { app } from 'electron';
+import log from 'electron-log';
+
+import { isProduction } from './utils';
+
+export default (): void => {
+  // Electron stores everything related to the app (cache, local storage,
+  // databases, logs, etc.) in a directory in the user's home directory.
+  // Prevent dev from colliding with prod by adding a suffix.
+  if (!isProduction()) {
+    app.setPath(`userData`, `${app.getPath(`userData`)}-development`);
+  }
+
+  log.info(`User Data: ${app.getPath(`userData`)}`);
+};

--- a/src/background/setUserDataPath.ts
+++ b/src/background/setUserDataPath.ts
@@ -1,15 +1,20 @@
+import path from 'path';
+
 import { app } from 'electron';
 import log from 'electron-log';
 
 import { isProduction } from './utils';
 
 export default (): void => {
-  // Electron stores everything related to the app (cache, local storage,
-  // databases, logs, etc.) in a directory in the user's home directory.
-  // Prevent dev from colliding with prod by adding a suffix.
   if (!isProduction()) {
+    // Electron stores everything related to the app (cache, local storage,
+    // databases, logs, etc.) in a directory in the user's home directory.
+    // Prevent dev from colliding with prod by adding a suffix.
     app.setPath(`userData`, `${app.getPath(`userData`)}-development`);
-  }
 
-  log.info(`User Data: ${app.getPath(`userData`)}`);
+    // Make sure the main logger writes to the new user data path
+    log.transports.file.resolvePath = (): string => {
+      return path.join(app.getPath(`userData`), `logs`, `main.log`);
+    };
+  }
 };

--- a/src/background/useTrayService/utils/getBaseMenuItems.ts
+++ b/src/background/useTrayService/utils/getBaseMenuItems.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/electron/main';
-import { MenuItemConstructorOptions } from 'electron';
+import { MenuItemConstructorOptions, dialog } from 'electron';
 import log from 'electron-log';
 
 import { State } from '../../types';
@@ -32,6 +32,16 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
         `Detected click on Send Bug Report menu item; sending Sentry alert`
       );
       Sentry.captureException(new Error(`Manual bug report`));
+
+      if (
+        state.windows.transparent &&
+        !state.windows.transparent.isDestroyed()
+      ) {
+        dialog.showErrorBox(
+          `Bug report submitted`,
+          `Oh snap! Sorry about that. We'll look into this. Please send us a brief description and screenshot via your company's Slack Connect channel or email us at support@swivvel.io. We'll get back to you ASAP.`
+        );
+      }
     },
   });
 

--- a/src/background/useTrayService/utils/getBaseMenuItems.ts
+++ b/src/background/useTrayService/utils/getBaseMenuItems.ts
@@ -1,5 +1,3 @@
-import fs from 'fs';
-
 import * as Sentry from '@sentry/electron/main';
 import { MenuItemConstructorOptions } from 'electron';
 import log from 'electron-log';
@@ -30,20 +28,10 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
     label: `Send Bug Report`,
     type: `normal`,
     click: (): void => {
-      log.info(`Detected click on Send Bug Report menu item`);
-
-      const logFilePath = log.transports.file.getFile().path;
-      log.info(`logFilePath=${logFilePath}`);
-
-      log.info(`Reading log file...`);
-      const logFileContents = fs.readFileSync(logFilePath).toString();
-
-      Sentry.configureScope((scope) => {
-        log.info(`Sending log file via Sentry...`);
-        scope.addAttachment({ filename: `main.log`, data: logFileContents });
-        Sentry.captureException(new Error(`Manual bug report`));
-        log.info(`Sent log file via Sentry`);
-      });
+      log.info(
+        `Detected click on Send Bug Report menu item; sending Sentry alert`
+      );
+      Sentry.captureException(new Error(`Manual bug report`));
     },
   });
 

--- a/src/background/useTrayService/utils/getBaseMenuItems.ts
+++ b/src/background/useTrayService/utils/getBaseMenuItems.ts
@@ -32,16 +32,10 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
         `Detected click on Send Bug Report menu item; sending Sentry alert`
       );
       Sentry.captureException(new Error(`Manual bug report`));
-
-      if (
-        state.windows.transparent &&
-        !state.windows.transparent.isDestroyed()
-      ) {
-        dialog.showErrorBox(
-          `Bug report submitted`,
-          `Oh snap! Sorry about that. We'll look into this. Please send us a brief description and screenshot via your company's Slack Connect channel or email us at support@swivvel.io. We'll get back to you ASAP.`
-        );
-      }
+      dialog.showErrorBox(
+        `Bug report submitted`,
+        `Oh snap! Sorry about that. We'll look into this. Please send us a brief description and screenshot via your company's Slack Connect channel or email us at support@swivvel.io. We'll get back to you ASAP.`
+      );
     },
   });
 

--- a/src/background/useTrayService/utils/getBaseMenuItems.ts
+++ b/src/background/useTrayService/utils/getBaseMenuItems.ts
@@ -1,4 +1,8 @@
+import fs from 'fs';
+
+import * as Sentry from '@sentry/electron/main';
 import { MenuItemConstructorOptions } from 'electron';
+import log from 'electron-log';
 
 import { State } from '../../types';
 import { isLinux, isProduction, quitApp } from '../../utils';
@@ -21,6 +25,27 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
       },
     });
   }
+
+  menuItems.push({
+    label: `Send Bug Report`,
+    type: `normal`,
+    click: (): void => {
+      log.info(`Detected click on Send Bug Report menu item`);
+
+      const logFilePath = log.transports.file.getFile().path;
+      log.info(`logFilePath=${logFilePath}`);
+
+      log.info(`Reading log file...`);
+      const logFileContents = fs.readFileSync(logFilePath).toString();
+
+      Sentry.configureScope((scope) => {
+        log.info(`Sending log file via Sentry...`);
+        scope.addAttachment({ filename: `main.log`, data: logFileContents });
+        Sentry.captureException(new Error(`Manual bug report`));
+        log.info(`Sent log file via Sentry`);
+      });
+    },
+  });
 
   menuItems.push({
     label: `Quit Swivvel`,

--- a/src/background/useWindowService/openTransparentWindow/getLogger.ts
+++ b/src/background/useWindowService/openTransparentWindow/getLogger.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+
+import { app } from 'electron';
+import log from 'electron-log';
+
+let globalLogger: log.ElectronLog | null = null;
+
+/**
+ * Get a logger that writes to a different file than the main logger.
+ */
+export default (name: string): log.ElectronLog => {
+  if (!globalLogger) {
+    log.info(`Initializing logger: ${name}`);
+
+    globalLogger = log.create(name);
+    globalLogger.transports.console.level = false;
+    globalLogger.transports.file.resolvePath = (): string => {
+      return path.join(app.getPath(`userData`), `logs`, `${name}.log`);
+    };
+  }
+
+  return globalLogger;
+};

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -2,6 +2,7 @@ import { getSiteUrl, isLinux, loadUrl, sleep } from '../../utils';
 import { openBrowserWindow } from '../utils';
 
 import configureCloseHandler from './configureCloseHandler';
+import getLogger from './getLogger';
 import getTransparentBrowserWindowOptions from './getTransparentBrowserWindowOptions';
 import pollForMouseEvents from './pollForMouseEvents';
 import resizeOnDisplayChange from './resizeOnDisplayChange';
@@ -11,6 +12,7 @@ import { OpenTransparentWindow } from './types';
 const openTransparentWindow: OpenTransparentWindow = async (args) => {
   const { state, windowOpenRequestHandler } = args;
 
+  const transparentWindowLog = getLogger(`transparent`);
   const options = getTransparentBrowserWindowOptions();
 
   return openBrowserWindow(state, `transparent`, options, async (window) => {
@@ -25,6 +27,10 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
     // On Linux, calling `showInactive()` causes the window to no longer appear
     // on top, so we have to explicitly re-enable the always-on-top setting.
     window.setAlwaysOnTop(true);
+
+    window.webContents.on(`console-message`, (event, level, message) => {
+      transparentWindowLog.info(message);
+    });
 
     // Transparent windows don't work on Linux without some hacks
     // like this short delay

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -28,9 +28,13 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
     // on top, so we have to explicitly re-enable the always-on-top setting.
     window.setAlwaysOnTop(true);
 
+    // Write all console messages to a log file so that we can include the file
+    // in Sentry alerts.
     window.webContents.on(`console-message`, (event, level, message) => {
       transparentWindowLog.info(message);
     });
+
+    window.webContents.setWindowOpenHandler(windowOpenRequestHandler);
 
     // Transparent windows don't work on Linux without some hacks
     // like this short delay
@@ -38,8 +42,6 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
     if (isLinux()) {
       await sleep(1000);
     }
-
-    window.webContents.setWindowOpenHandler(windowOpenRequestHandler);
 
     showOnAllWorkspaces(window);
     configureCloseHandler(window, state);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -7,7 +7,7 @@ import { ShareableMediaSource } from './types';
 
 contextBridge.exposeInMainWorld(`electron`, {
   featureFlags: {
-    loginFlowV2: true, // Deprecated: remove when all clients on v1.2.0
+    loginFlowV2: true, // Remove when all clients on v1.2.0
     googleMeetsSupport: true, // Remove when all clients on v1.2.18
   },
 
@@ -31,6 +31,15 @@ contextBridge.exposeInMainWorld(`electron`, {
    */
   getIsProduction: (): Promise<boolean> => {
     return ipcRenderer.invoke(`isProduction`);
+  },
+
+  /**
+   * Used by the app windows to inform the main process who the user is after
+   * they authenticate. The user information is included in Sentry error
+   * reports.
+   */
+  identifyUser: (user: { id: string; email: string | null } | null) => {
+    ipcRenderer.send(`identifyUser`, user);
   },
 
   /**
@@ -139,7 +148,6 @@ contextBridge.exposeInMainWorld(`electron`, {
    */
   onMeetJoined: (callback: MeetJoinedCallback) => {
     ipcRenderer.on(`meetJoined`, callback);
-
     return (): void => {
       ipcRenderer.removeListener(`meetJoined`, callback);
     };
@@ -151,7 +159,6 @@ contextBridge.exposeInMainWorld(`electron`, {
    */
   onMeetLeft: (callback: MeetLeftCallback) => {
     ipcRenderer.on(`meetLeft`, callback);
-
     return (): void => {
       ipcRenderer.removeListener(`meetLeft`, callback);
     };


### PR DESCRIPTION
## The Problem

We don't have a lot of visibility into errors that users encounter in the Electron app. Right now our debugging process requires us to ask the user to explain the issue and manually send us the console logs and the Electron log file. This makes it difficult to debug issues.

## The Solution

Add automatic Sentry error reporting, as well as a new "Send Bug Report" item in the tray menu that will attach the Electron `main.log` file with the Sentry alert.

## Other Changes

Change `npm run dev` to `electron .` because the development environment wasn't detecting our `package.json` so it was using the app name `Electron` instead of `Swivvel`. This was causing log files to be written to an `Electron-development/` directory.