### PR TITLE
Fix `powerMonitor` timeout bugs and add extra logs

### DIFF
--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -39,33 +39,45 @@ export default (state: State, windowService: WindowService): void => {
     log.info(`Power monitor: lock-screen detected`);
 
     if (timeout) {
+      log.info(
+        `Power monitor: lock-screen: window close timeout already exists; clearing timeout`
+      );
       clearTimeout(timeout);
     }
 
+    log.info(`Power monitor: lock-screen: setting new window close timeout...`);
     timeout = setTimeout(() => {
+      log.info(`Power monitor: lock-screen: window close timeout reached`);
       windowService.closeAllWindows();
+      log.info(
+        `Power monitor: lock-screen: setting window close timeout to null`
+      );
       timeout = null;
-      log.info(`Power monitor lock-screen (timeout): closed all windows`);
     }, TEN_MIN_MS);
   });
   powerMonitor.on(`suspend`, () => {
     log.info(`Power monitor: suspend detected`);
 
     if (timeout) {
+      log.info(
+        `Power monitor: suspend: window close timeout already exists; clearing timeout`
+      );
       clearTimeout(timeout);
     }
 
+    log.info(`Power monitor: suspend: setting new window close timeout...`);
     timeout = setTimeout(() => {
+      log.info(`Power monitor: suspend: window close timeout reached`);
       windowService.closeAllWindows();
+      log.info(`Power monitor: suspend: setting window close timeout to null`);
       timeout = null;
-      log.info(`Power monitor suspend (timeout): closed all windows`);
     }, TEN_MIN_MS);
   });
   powerMonitor.on(`unlock-screen`, () => {
     log.info(`Power monitor: unlock-screen detected`);
 
     if (timeout) {
-      log.info(`Power monitor: clearing timeout`);
+      log.info(`Power monitor: unlock-screen: clearing timeout`);
       clearTimeout(timeout);
     }
 
@@ -75,7 +87,7 @@ export default (state: State, windowService: WindowService): void => {
     log.info(`Power monitor: resume detected`);
 
     if (timeout) {
-      log.info(`Power monitor: clearing timeout`);
+      log.info(`Power monitor: resume: clearing timeout`);
       clearTimeout(timeout);
     }
 

--- a/src/background/handlePowerMonitorStateChanges.ts
+++ b/src/background/handlePowerMonitorStateChanges.ts
@@ -44,8 +44,8 @@ export default (state: State, windowService: WindowService): void => {
 
     timeout = setTimeout(() => {
       windowService.closeAllWindows();
-
       timeout = null;
+      log.info(`Power monitor lock-screen (timeout): closed all windows`);
     }, TEN_MIN_MS);
   });
   powerMonitor.on(`suspend`, () => {
@@ -57,27 +57,29 @@ export default (state: State, windowService: WindowService): void => {
 
     timeout = setTimeout(() => {
       windowService.closeAllWindows();
-
       timeout = null;
+      log.info(`Power monitor suspend (timeout): closed all windows`);
     }, TEN_MIN_MS);
   });
   powerMonitor.on(`unlock-screen`, () => {
     log.info(`Power monitor: unlock-screen detected`);
 
     if (timeout) {
+      log.info(`Power monitor: clearing timeout`);
       clearTimeout(timeout);
-    } else {
-      windowService.openTransparentWindow();
     }
+
+    windowService.openTransparentWindow();
   });
   powerMonitor.on(`resume`, () => {
     log.info(`Power monitor: resume detected`);
 
     if (timeout) {
+      log.info(`Power monitor: clearing timeout`);
       clearTimeout(timeout);
-    } else {
-      windowService.openTransparentWindow();
     }
+
+    windowService.openTransparentWindow();
   });
 
   // Without this, Macs would hang when trying to shut down because the


### PR DESCRIPTION
## The Problem
Brian ran into [This Bug](https://swivvel.slack.com/archives/C041MFH7VMF/p1697127153690059), which came from the recent change in `handlePowerMonitorStateChanges` - Where I set it up to close the windows after 10 minutes. 

But if the window closed and we still had the timeout, the `transparentWindow` never opened. Causing a state where we can't get that open again
<!--
  Describe the product or technical problem you are solving with this PR.
  Provide as much business context as possible. This problem description should
  be able to stand on its own without linking out to other resources, but feel
  free to include links to provide helpful context.
-->

## The Solution
Always open the windows even if there is a `timeout`. Since if the window already exists it will use that one

## Other Changes
Add extra logging with more information so we can properly debug this if another error occurs.
