### PR TITLE
Stop writing idle poller log line every second

### DIFF
--- a/src/background/pollForIdleTime.ts
+++ b/src/background/pollForIdleTime.ts
@@ -41,25 +41,25 @@ export default (state: State): void => {
       const key = getKey(idleChangeEvent);
       log.info(`Adding idle change event to buffer: ${key}`);
       buffer.set(getKey(idleChangeEvent), idleChangeEvent);
+      log.info(`Idle change events buffered: ${buffer.size}`);
     }
 
-    if (buffer.size > 0) {
-      log.info(`Idle change events buffered: ${buffer.size}`);
-
+    if (
+      buffer.size > 0 &&
+      state.windows.transparent &&
+      !state.windows.transparent.isDestroyed()
+    ) {
       // Note: we are purposefully not logging when the transparent window is
       // missing because we close the transparent window when someone locks
       // or sleeps their computer, so we could end up writing a log line every
       // second for hours.
-      if (
-        state.windows.transparent &&
-        !state.windows.transparent.isDestroyed()
-      ) {
-        log.info(`Reporting idle change to transparent window...`);
-        state.windows.transparent.webContents.send(
-          `idleChangeEventsBuffered`,
-          Array.from(buffer.values())
-        );
-      }
+      log.info(
+        `Reporting ${buffer.size} idle change events to transparent window`
+      );
+      state.windows.transparent.webContents.send(
+        `idleChangeEventsBuffered`,
+        Array.from(buffer.values())
+      );
     }
   }, 1000);
 


### PR DESCRIPTION
## The Problem

In commit 8bd2bf8890b06995ec449ee8a7d2fe4b673195a0, we attempted to fix a bug in the idle poller where we could end up writing a log line every second for hours. When someone locks their screen or suspends their computer, we close the transparent window. If there is an idle change event in the buffer, it'll be stuck there until the transparent window opens again. Sometimes the computer isn't unlocked/resumed for hours, causing us to write a log line every second for a very long time, polluting the log.

However, even after that commit there was still a log line in the idle poller that was getting written every second.

## The Solution

Stop logging how many events are in the buffer unless the transparent window is available to receive those events.