### PR TITLE
Use unique fingerprint for manual bug report Sentry alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
         "electron-serve": "^1.1.0",
         "electron-store": "^8.1.0",
         "electron-updater": "^6.1.4",
-        "ms": "^2.1.3"
+        "ms": "^2.1.3",
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
+        "@types/uuid": "^9.0.5",
         "@typescript-eslint/eslint-plugin": "^6.7.4",
         "@typescript-eslint/parser": "^6.7.4",
         "electron": "^26.2.4",
@@ -901,6 +903,12 @@
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
       "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.5.tgz",
+      "integrity": "sha512-xfHdwa1FMJ082prjSJpoEI57GZITiQz10r3vEJCHa2khEFQjKy91aWKz6+zybzssCvXUwE1LQWgWVwZ4nYUvHQ==",
       "dev": true
     },
     "node_modules/@types/verror": {
@@ -6719,6 +6727,18 @@
       "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
       "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -70,9 +70,11 @@
     "electron-serve": "^1.1.0",
     "electron-store": "^8.1.0",
     "electron-updater": "^6.1.4",
-    "ms": "^2.1.3"
+    "ms": "^2.1.3",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@types/uuid": "^9.0.5",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "electron": "^26.2.4",

--- a/src/background/useTrayService/utils/getBaseMenuItems.ts
+++ b/src/background/useTrayService/utils/getBaseMenuItems.ts
@@ -38,7 +38,8 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
         scope.setFingerprint([uuidv4()]);
 
         const userEmail = scope.getUser()?.email || `no user`;
-        const message = `Manual bug report - ${userEmail}`;
+        const now = new Date().toISOString();
+        const message = `Manual bug report - ${userEmail} - ${now}`;
         Sentry.captureException(new Error(message));
       });
       dialog.showErrorBox(

--- a/src/background/useTrayService/utils/getBaseMenuItems.ts
+++ b/src/background/useTrayService/utils/getBaseMenuItems.ts
@@ -31,7 +31,15 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
       log.info(
         `Detected click on Send Bug Report menu item; sending Sentry alert`
       );
-      Sentry.captureException(new Error(`Manual bug report`));
+      Sentry.withScope((scope) => {
+        const userEmail = scope.getUser()?.email || `no user`;
+        const now = new Date().toISOString();
+        Sentry.captureException(
+          // Use a unique error message to avoid grouping in Sentry so that we
+          // don't accidentally miss an alert about a manual bug report
+          new Error(`Manual bug report - ${userEmail} - ${now}`)
+        );
+      });
       dialog.showErrorBox(
         `Bug report submitted`,
         `Oh snap! Sorry about that. We'll look into this. Please send us a brief description and screenshot via your company's Slack Connect channel or email us at support@swivvel.io. We'll get back to you ASAP.`


### PR DESCRIPTION
## The Problem

In commit 571dd85205a99f3f03eff18b8eec872463b9cf47, we added the ability for users to easily send us their log files by clicking a "Send Bug Report" menu item in the tray menu. This triggers a Sentry alert with the title "Manual bug report" and attaches the log files.

However, we realized that Sentry ends up grouping these alerts, so it would be very easy to accidentally miss one.

## The Solution

Use a unique fingerprint for the manual bug report Sentry alert so that it never gets grouped.

I also added the user's email address and current time to the alert message so we have a little more context when looking at a list of manual bug report Sentry alerts.
