### PR TITLE
Use `mousemove` to detect when mouse over transparent area

### DIFF
--- a/src/background/configureIpcHandlers.ts
+++ b/src/background/configureIpcHandlers.ts
@@ -8,10 +8,6 @@ import { WindowService } from './useWindowService';
 import { getShareableMediaSources, isProduction } from './utils';
 
 export default (windowService: WindowService): void => {
-  ipcMain.on(`log`, (event, msg: string): void => {
-    console.log(msg);
-  });
-
   ipcMain.handle(`getDesktopAppVersion`, () => {
     return app.getVersion();
   });

--- a/src/background/configureIpcHandlers.ts
+++ b/src/background/configureIpcHandlers.ts
@@ -8,6 +8,10 @@ import { WindowService } from './useWindowService';
 import { getShareableMediaSources, isProduction } from './utils';
 
 export default (windowService: WindowService): void => {
+  ipcMain.on(`log`, (event, msg: string): void => {
+    console.log(msg);
+  });
+
   ipcMain.handle(`getDesktopAppVersion`, () => {
     return app.getVersion();
   });

--- a/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
+++ b/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
@@ -13,7 +13,7 @@ import { isMac } from '../../utils';
  *
  * There are a few strategies to accomplish this with varying pros and cons and
  * varying OS support. There is a long GitHub issue about this here:
- * https://github.com/electron/electron/issues/1335#issuecomment-1585787243
+ * https://github.com/electron/electron/issues/1335
  */
 export default (transparentWindow: BrowserWindow): void => {
   log.info(`Configuring transparent window mouse pass-through handler`);
@@ -38,6 +38,10 @@ export default (transparentWindow: BrowserWindow): void => {
   // but unfortunately the `forward` option was not working on Windows or
   // Linux, meaning that the `mousemove` event in the web contents would stop
   // triggering after calling `setIgnoreMouseEvents(true)`.
+  //
+  // This strategy is inspired by:
+  // https://github.com/electron/electron/issues/1335#issuecomment-571066967
+  //
   if (isMac()) {
     log.info(`Mouse pass-through strategy: mousemove`);
 
@@ -71,6 +75,9 @@ export default (transparentWindow: BrowserWindow): void => {
   // window and we should ignore mouse events. If the pixel is not transparent,
   // then the user's cursor is over a non-transparent part of the window and we
   // should not ignore mouse events.
+  //
+  // This strategy is inspired by:
+  // https://github.com/electron/electron/issues/1335#issuecomment-1585787243
 
   log.info(`Mouse pass-through strategy: poll`);
 

--- a/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
+++ b/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
@@ -61,6 +61,8 @@ export default (transparentWindow: BrowserWindow): void => {
         isOverTransparencyPrevious = isOverTransparency;
       }
     );
+
+    return;
   }
 
   // On windows and Linux, our strategy is to periodically capture a 1x1 image

--- a/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
+++ b/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
@@ -16,6 +16,8 @@ import { isMac } from '../../utils';
  * https://github.com/electron/electron/issues/1335#issuecomment-1585787243
  */
 export default (transparentWindow: BrowserWindow): void => {
+  log.info(`Configuring transparent window mouse pass-through handler`);
+
   // On Mac, we originally used the polling screenshot strategy, but users were
   // getting an issue trying to use the "Capture Selected Window" screenshot
   // option. Even when mouse events were disabled on the transparent window,
@@ -37,6 +39,8 @@ export default (transparentWindow: BrowserWindow): void => {
   // Linux, meaning that the `mousemove` event in the web contents would stop
   // triggering after calling `setIgnoreMouseEvents(true)`.
   if (isMac()) {
+    log.info(`Mouse pass-through strategy: mousemove`);
+
     transparentWindow.setIgnoreMouseEvents(true, { forward: true });
 
     let isOverTransparencyPrevious: boolean | null = null;
@@ -65,6 +69,10 @@ export default (transparentWindow: BrowserWindow): void => {
   // window and we should ignore mouse events. If the pixel is not transparent,
   // then the user's cursor is over a non-transparent part of the window and we
   // should not ignore mouse events.
+
+  log.info(`Mouse pass-through strategy: poll`);
+
+  transparentWindow.setIgnoreMouseEvents(true);
 
   let mouseIsOverTransparentPrevious: boolean | null = null;
 

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -2,9 +2,9 @@ import { getSiteUrl, isLinux, loadUrl, sleep } from '../../utils';
 import { openBrowserWindow } from '../utils';
 
 import configureCloseHandler from './configureCloseHandler';
+import configureMousePassThroughHandler from './configureMousePassThroughHandler';
 import getLogger from './getLogger';
 import getTransparentBrowserWindowOptions from './getTransparentBrowserWindowOptions';
-import pollForMouseEvents from './pollForMouseEvents';
 import resizeOnDisplayChange from './resizeOnDisplayChange';
 import showOnAllWorkspaces from './showOnAllWorkspaces';
 import { OpenTransparentWindow } from './types';
@@ -45,7 +45,7 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
 
     showOnAllWorkspaces(window);
     configureCloseHandler(window, state);
-    pollForMouseEvents(window);
+    configureMousePassThroughHandler(window);
     resizeOnDisplayChange(window);
 
     await loadUrl(`${getSiteUrl()}/notifications`, window, state, {

--- a/src/background/useWindowService/openTransparentWindow/pollForMouseEvents.ts
+++ b/src/background/useWindowService/openTransparentWindow/pollForMouseEvents.ts
@@ -22,6 +22,7 @@ export default (transparentWindow: BrowserWindow): void => {
 
   ipcMain.on(`log`, (event, msg: string): void => {
     console.log(msg);
+    transparentWindow.setIgnoreMouseEvents(msg === `true`, { forward: true });
   });
 
   /*

--- a/src/background/useWindowService/openTransparentWindow/pollForMouseEvents.ts
+++ b/src/background/useWindowService/openTransparentWindow/pollForMouseEvents.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, screen } from 'electron';
+import { BrowserWindow, ipcMain, screen } from 'electron';
 import log from 'electron-log';
 
 /**
@@ -18,8 +18,13 @@ import log from 'electron-log';
  * transparent part of the window and we should not ignore mouse events.
  */
 export default (transparentWindow: BrowserWindow): void => {
-  transparentWindow.setIgnoreMouseEvents(true);
+  transparentWindow.setIgnoreMouseEvents(true, { forward: true });
 
+  ipcMain.on(`log`, (event, msg: string): void => {
+    console.log(msg);
+  });
+
+  /*
   let mouseIsOverTransparentPrevious: boolean | null = null;
 
   const interval = setInterval(async () => {
@@ -68,4 +73,5 @@ export default (transparentWindow: BrowserWindow): void => {
       mouseIsOverTransparentPrevious = mouseIsOverTransparent;
     }
   }, 50);
+  */
 };

--- a/src/background/useWindowService/openTransparentWindow/pollForMouseEvents.ts
+++ b/src/background/useWindowService/openTransparentWindow/pollForMouseEvents.ts
@@ -1,6 +1,8 @@
 import { BrowserWindow, ipcMain, screen } from 'electron';
 import log from 'electron-log';
 
+import { isMac } from '../../utils';
+
 /**
  * Support mouse events on the transparent notification window.
  *
@@ -9,23 +11,61 @@ import log from 'electron-log';
  * over an element that we rendered in the notification window, we need to stop
  * ignoring mouse events so that the user can interact with the element.
  *
- * There are a few strategies to accomplish this, but the most reliable we found
- * was https://github.com/electron/electron/issues/1335#issuecomment-1585787243.
- * This works by periodically capturing a 1x1 image of the pixel at the user's
- * current cursor position. If the pixel is transparent, then the user's cursor
- * is over a transparent part of the window and we should ignore mouse events.
- * If the pixel is not transparent, then the user's cursor is over a non-
- * transparent part of the window and we should not ignore mouse events.
+ * There are a few strategies to accomplish this with varying pros and cons and
+ * varying OS support. There is a long GitHub issue about this here:
+ * https://github.com/electron/electron/issues/1335#issuecomment-1585787243
  */
 export default (transparentWindow: BrowserWindow): void => {
-  transparentWindow.setIgnoreMouseEvents(true, { forward: true });
+  // On Mac, we originally used the polling screenshot strategy, but users were
+  // getting an issue trying to use the "Capture Selected Window" screenshot
+  // option. Even when mouse events were disabled on the transparent window,
+  // users could not select any window underneath as the screenshot target.
+  // We think that calling `webContents.capturePage()` was somehow causing the
+  // screenshot tool to always detect the transparent window as being on top of
+  // everything else, but we weren't able to confirm this 100%.
+  //
+  // To fix this, we use a different strategy on Mac. We use the `forward`
+  // option of `setIgnoreMouseEvents()` to forward mouse events to the window
+  // event when mouse events are being ignored. The web contents register a
+  // `mousemove` listener that informs the Electron window whether the mouse
+  // is over the document (i.e. a transparent area of the window) or a child
+  // element (i.e. over an opaque area of the window).
+  //
+  // This strategy is much better than polling because it doesn't suffer from
+  // performance overhead of rapidly taking screenshots of a 1x1 pixel area,
+  // but unfortunately the `forward` option was not working on Windows or
+  // Linux, meaning that the `mousemove` event in the web contents would stop
+  // triggering after calling `setIgnoreMouseEvents(true)`.
+  if (isMac()) {
+    transparentWindow.setIgnoreMouseEvents(true, { forward: true });
 
-  ipcMain.on(`log`, (event, msg: string): void => {
-    console.log(msg);
-    transparentWindow.setIgnoreMouseEvents(msg === `true`, { forward: true });
-  });
+    let isOverTransparencyPrevious: boolean | null = null;
 
-  /*
+    ipcMain.on(
+      `onMouseOverTransparentArea`,
+      (event, isOverTransparency: boolean): void => {
+        transparentWindow.setIgnoreMouseEvents(isOverTransparency, {
+          forward: true,
+        });
+
+        if (isOverTransparency !== isOverTransparencyPrevious) {
+          log.info(
+            `Mouse is over transparent: ${isOverTransparencyPrevious} -> ${isOverTransparency}`
+          );
+        }
+
+        isOverTransparencyPrevious = isOverTransparency;
+      }
+    );
+  }
+
+  // On windows and Linux, our strategy is to periodically capture a 1x1 image
+  // of the pixel at the user's current cursor position. If the pixel is
+  // transparent, then the user's cursor is over a transparent part of the
+  // window and we should ignore mouse events. If the pixel is not transparent,
+  // then the user's cursor is over a non-transparent part of the window and we
+  // should not ignore mouse events.
+
   let mouseIsOverTransparentPrevious: boolean | null = null;
 
   const interval = setInterval(async () => {
@@ -74,5 +114,4 @@ export default (transparentWindow: BrowserWindow): void => {
       mouseIsOverTransparentPrevious = mouseIsOverTransparent;
     }
   }, 50);
-  */
 };

--- a/src/background/utils/index.ts
+++ b/src/background/utils/index.ts
@@ -5,6 +5,7 @@ import getPreloadPath from './getPreloadPath';
 import getShareableMediaSources from './getShareableMediaSources';
 import getSiteUrl from './getSiteUrl';
 import isLinux from './isLinux';
+import isMac from './isMac';
 import isProduction from './isProduction';
 import loadUrl from './loadUrl';
 import parseQueryParams from './parseQueryParams';
@@ -23,6 +24,7 @@ export {
   getShareableMediaSources,
   getSiteUrl,
   isLinux,
+  isMac,
   isProduction,
   loadUrl,
   parseQueryParams,

--- a/src/background/utils/isMac.ts
+++ b/src/background/utils/isMac.ts
@@ -1,0 +1,3 @@
+export default (): boolean => {
+  return process.platform === `darwin`;
+};

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -48,6 +48,11 @@ contextBridge.exposeInMainWorld(`electron`, {
   isLinux: process.platform === `linux`,
 
   /**
+   * True if desktop app is running on Mac
+   */
+  isMac: process.platform === `darwin`,
+
+  /**
    * Inform the transparent window that the user is requesting to join the
    * audio room for the given pod. Allows users to join audio room from other
    * windows.

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,10 +6,6 @@ import { ShareableMediaSource } from './types';
 // in the web app
 
 contextBridge.exposeInMainWorld(`electron`, {
-  log: (msg: string) => {
-    ipcRenderer.send(`log`, msg);
-  },
-
   featureFlags: {
     loginFlowV2: true, // Remove when all clients on v1.2.0
     googleMeetsSupport: true, // Remove when all clients on v1.2.18
@@ -166,6 +162,15 @@ contextBridge.exposeInMainWorld(`electron`, {
     return (): void => {
       ipcRenderer.removeListener(`meetLeft`, callback);
     };
+  },
+
+  /**
+   * Allows the transparent window to report when the mouse is over a
+   * transparent area or an element so that the Electron process can decide
+   * whether to ignore mouse events.
+   */
+  onMouseOverTransparentArea: (isOverTransparency: boolean) => {
+    ipcRenderer.send(`onMouseOverTransparentArea`, isOverTransparency);
   },
 });
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -6,6 +6,10 @@ import { ShareableMediaSource } from './types';
 // in the web app
 
 contextBridge.exposeInMainWorld(`electron`, {
+  log: (msg: string) => {
+    ipcRenderer.send(`log`, msg);
+  },
+
   featureFlags: {
     loginFlowV2: true, // Remove when all clients on v1.2.0
     googleMeetsSupport: true, // Remove when all clients on v1.2.18


### PR DESCRIPTION
## The Problem

Users were reporting that they tried to take a screenshot of a window on Mac and the screenshot ended up being a blank screen with the widget in it.

In commit a375ef619c69497c43557c6a61ca2428d37de8a6, we attempted to fix this by calling `window.setContentProtection(true)` on the transparent window. This is supposed to prevent apps from taking screenshots of the transparent window.

However, after releasing that change, users got a new issue when trying to take screenshots. Instead of being a blank page, they would get an error.

It turns out that this error only happens when using the "Capture Selected Window" screenshot option. This option allows you to select a specific window for the screenshot. But when users tried this, they could only select the transparent window, not any windows underneath. This is why they initially got a screenshot of the widget, and then later got an error because `window.setContentProtection(true)` would no allow the user to take a screenshot of the transparent window.

## The Solution

After some trial and error, I _think_ that I narrowed the issue down to calling `transparentWindow.webContents.capturePage()` in a loop. When I commented out this line, the screenshot tool no longer allowed the user to select the transparent window as a screenshot target.

Unfortunately, we can't use the polling strategy without calling `capturePage()`, so I had to see if there were ways I could work around this. I tried a bunch of things:

- Detect if the user is taking a screenshot and hide the transparent window. I couldn't find an event for this though. I experimented with listening for the screenshot keyboard shortcut, but this suffered from two issues: 1) we wouldn't know when the screenshot was done, 2) users could initiate a screenshot without using the keyboard shortcuts.
- Blur the transparent window when the mouse is over a transparent pixel. This seemed to work sometimes, but not consistently.
- Call `transparentWindow.setFocusable(false)` when the mouse is over a transparent pixel. This didn't work at all, and prevented the window from ever becoming focused again.
- Add an [input-event](https://www.electronjs.org/docs/latest/api/web-contents#event-input-event) listener in the transparent window web contents and only call `capturePage()` when the mouse is moving. This seemed to work at first because the input event listener would stop getting called while the user was selecting the screenshot window target. However, this solution was also inconsistent. It was possible to get in a state where the screenshot window selector would still recognize the transparent window but not the windows underneath.

Eventually, I returned to the Electron GitHub issue that originally inspired the poll+screenshot strategy and looked for a complete alternative to the poll+screenshot strategy. I found a strategy that seems to work well.

The new strategy uses the `forward` option of `setIgnoreMouseEvents()` to forward mouse events to the window event when mouse events are being ignored. The web contents register a `mousemove` listener that informs the Electron window whether the mouse is over the document (i.e. a transparent area of the window) or a child element (i.e. over an opaque area of the window). The Electron window then enables or disables the mouse pass-through on the transparent window.

This strategy is much better than polling because it doesn't suffer from performance overhead of rapidly taking screenshots of a 1x1 pixel area, but unfortunately the `forward` option was not working on Windows or Linux (even though it is documented as being supported on Windows), meaning that the `mousemove` event in the web contents would stop triggering after calling `setIgnoreMouseEvents(true)`. So we're continuing to use the polling strategy for Windows and Linux.