### PR TITLE
Write transparent window logs & dev logs to correct directory

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -22,6 +22,7 @@ setUserDataPath();
 const run = async (): Promise<void> => {
   log.info(`App v=${app.getVersion()} starting...`);
   log.info(`User Data: ${app.getPath(`userData`)}`);
+  log.info(`Logs: ${app.getPath(`logs`)}`);
 
   // Call at the beginning so that all exceptions are captured
   configureSentry();

--- a/src/background/setUserDataPath.ts
+++ b/src/background/setUserDataPath.ts
@@ -19,9 +19,6 @@ export default (): void => {
     app.setPath(`userData`, userDataDev);
     app.setPath(`logs`, logsDev);
 
-    console.log(`---------------------------------`);
-    console.log(logsDev);
-
     // Make sure the main logger writes to the new log path
     log.transports.file.resolvePath = (): string => {
       return path.join(logsDev, `main.log`);

--- a/src/background/setUserDataPath.ts
+++ b/src/background/setUserDataPath.ts
@@ -7,15 +7,24 @@ import { isProduction } from './utils';
 
 export default (): void => {
   if (!isProduction()) {
-    // Electron stores everything related to the app (cache, local storage,
-    // databases, logs, etc.) in a directory in the user's home directory.
-    // Prevent dev from colliding with prod by adding a suffix.
-    const userDataPath = `${app.getPath(`userData`)}-development`;
-    app.setPath(`userData`, userDataPath);
+    const userDataProd = app.getPath(`userData`);
+    const logsProd = app.getPath(`logs`);
 
-    // Make sure the main logger writes to the new user data path
+    // The paths that Electron uses for storing app data are derived from
+    // the app name, Swivvel. To prevent development data from colliding
+    // with prod data, we add a suffix.
+    const userDataDev = userDataProd.replace(`Swivvel`, `Swivvel-development`);
+    const logsDev = logsProd.replace(`Swivvel`, `Swivvel-development`);
+
+    app.setPath(`userData`, userDataDev);
+    app.setPath(`logs`, logsDev);
+
+    console.log(`---------------------------------`);
+    console.log(logsDev);
+
+    // Make sure the main logger writes to the new log path
     log.transports.file.resolvePath = (): string => {
-      return path.join(userDataPath, `logs`, `main.log`);
+      return path.join(logsDev, `main.log`);
     };
   }
 };

--- a/src/background/useWindowService/openTransparentWindow/getLogger.ts
+++ b/src/background/useWindowService/openTransparentWindow/getLogger.ts
@@ -10,12 +10,14 @@ let globalLogger: log.ElectronLog | null = null;
  */
 export default (name: string): log.ElectronLog => {
   if (!globalLogger) {
-    log.info(`Initializing logger: ${name}`);
+    const logPath = path.join(app.getPath(`logs`), `${name}.log`);
+
+    log.info(`Initializing logger '${name}' at path ${logPath}`);
 
     globalLogger = log.create(name);
     globalLogger.transports.console.level = false;
     globalLogger.transports.file.resolvePath = (): string => {
-      return path.join(app.getPath(`userData`), `logs`, `${name}.log`);
+      return logPath;
     };
   }
 


### PR DESCRIPTION
## The Problem

In commit 571dd85205a99f3f03eff18b8eec872463b9cf47, we made two changes related to logging:

1. We started writing logs from the transparent window into a file.
2. We fixed a bug where app data was stored in a directory called "Electron" instead of "Swivvel-development". Fixing this bug required us to explicitly configure the development logs to be written into the new "Swivvel-development" directory.

Both of these changes configured the log path using code like this:

```ts
path.join(app.getPath(`userData`), `logs`, `${name}.log`);
```

This worked on Windows and Linux because the log data is stored in a `logs/` sub-directory inside of the Electron user data directory.

However, on Mac the log files are _not_ stored in the user data directory. The user data is stored in `~/Library/Application Support/Swivvel/` whereas the logs are stored in `~/Library/Logs/Swivvel/`. The changes in commit 571dd85205a99f3f03eff18b8eec872463b9cf47 caused the logs to incorrectly be written to `~/Library/Application Support/Swivvel/logs`.

## The Solution

When configuring the log path, always use `app.getPath('logs')` as the base, not `app.getPath('userData')`.