### PR TITLE
Open transparent window without focus on unlock/resume

### DIFF
--- a/src/background/useWindowService/utils/openBrowserWindow.ts
+++ b/src/background/useWindowService/utils/openBrowserWindow.ts
@@ -25,8 +25,13 @@ export default async (
   const existingWindow = state.windows[browserWindowName];
 
   if (existingWindow && !existingWindow.isDestroyed()) {
-    log.info(`Showing existing window: ${browserWindowName}`);
-    existingWindow.show();
+    if (browserWindowOptions.show !== false) {
+      log.info(`Showing existing window w/ focus: ${browserWindowName}`);
+      existingWindow.show();
+    } else {
+      log.info(`Showing existing window w/o focus: ${browserWindowName}`);
+      existingWindow.showInactive();
+    }
     return existingWindow;
   }
 


### PR DESCRIPTION
## The Problem

When a user locks or sleeps their computer, we close all windows after 10 minutes. If they unlock or resume their computer within 10 minutes, we call `windowService.openTransparentWindow()`.

In this scenario, the transparent window already exists, so we end up just calling `window.show()`. This results in the transparent window getting focus. We don't want the transparent window to get focus when it doesn't need to because it can cause weird corner case bugs, e.g. with screenshots.

## The Solution

Use `showInactive()` to prevent an existing transparent window from getting focus when opened.

## Other Changes

Minor refactoring of `handlePowerMonitorStateChanges.ts` to remove code duplication.