### PR TITLE
Reduce log spam; check for updates every 10 minutes

### DIFF
--- a/src/background/configureAutoUpdates/configureAutoUpdates.ts
+++ b/src/background/configureAutoUpdates/configureAutoUpdates.ts
@@ -20,10 +20,6 @@ export default (state: State): void => {
     log.info(`Update available`);
   });
 
-  autoUpdater.on(`update-not-available`, () => {
-    log.info(`Update not available`);
-  });
-
   autoUpdater.on(`error`, (err) => {
     log.info(`Error in auto-updater: ${err}`);
   });

--- a/src/background/configureAutoUpdates/pollForUpdates.ts
+++ b/src/background/configureAutoUpdates/pollForUpdates.ts
@@ -1,4 +1,5 @@
 import { autoUpdater } from 'electron-updater';
+import ms from 'ms';
 
 /**
  * Check if there are any updates available for the app. If so, download
@@ -10,5 +11,5 @@ export default (): NodeJS.Timeout => {
 
   return setInterval(() => {
     autoUpdater.checkForUpdatesAndNotify();
-  }, 1000 * 60);
+  }, ms(`10 minutes`));
 };

--- a/src/background/pollForIdleTime.ts
+++ b/src/background/pollForIdleTime.ts
@@ -49,13 +49,12 @@ export default (state: State): void => {
       state.windows.transparent &&
       !state.windows.transparent.isDestroyed()
     ) {
-      // Note: we are purposefully not logging when the transparent window is
-      // missing because we close the transparent window when someone locks
-      // or sleeps their computer, so we could end up writing a log line every
-      // second for hours.
-      log.info(
-        `Reporting ${buffer.size} idle change events to transparent window`
-      );
+      // Note: we are purposefully not logging when we send the idle change
+      // events to the transparent window because the transparent window may
+      // be in a state where it can't process the event (e.g. the user is
+      // logged out). This would cause the log to get spammed with a log line
+      // every second until the transparent window can successfully process
+      // the event.
       state.windows.transparent.webContents.send(
         `idleChangeEventsBuffered`,
         Array.from(buffer.values())


### PR DESCRIPTION
## The Problem

There are two events that can cause a lot of spam in our logs:

1. When there are idle events buffered but they can't be handled by the transparent window (such as when the user is not logged in)
2. When the auto-updater checks for updates

## The Solution

Remove the log line that says when we are sending idle events to the transparent window. It's not ideal to lose this visibility, but the cleaner log is likely more important than having this log line. Also, we still write a log line every time a new event is added to the buffer, and whenever an event is successfully handled by the transparent window, so we aren't losing visibility completely.

For the auto-updater log lines, we made two changes:

- Only poll for updates every 10 minutes instead of every minute. We don't realistically need to be polling every minute. Increasing the poll interval to 10 minutes does mean that a user will have to have the app open for longer before the update is detected, but the app is intended to be open for a long time so this should be an ok tradeoff.
- Don't log when there is no update available. This is already logged by the auto-updater library, so we were writing two log lines whenever an update was not available.
