### PR TITLE
Add code signing for Windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  ignorePatterns: [`.eslintrc.js`, `compiled/`, `dist/`],
+  ignorePatterns: [`.eslintrc.js`, `compiled/`, `dist/`, `signWindows.js`],
   overrides: [
     {
       files: `*.{js,ts}`,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,10 +54,17 @@ jobs:
           mkdir -p ~/private_keys/
           echo '${{ env.APPLE_API_KEY }}' > ~/private_keys/AuthKey_${{ env.APPLE_API_KEY_ID }}.p8
 
-      - name: Setup Windows Signing Certificate and set env variables
+      - name: Setup Windows Signing Certificate
         if: startsWith(matrix.os, 'windows')
         run: |
           echo "${{ env.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+          cat  /d/Certificate_pkcs12.p12
+        shell: bash
+
+      - name: Set variables
+        if: startsWith(matrix.os, 'windows')
+        id: variables
+        run: |
           echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
           echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
       - name: Check out Git repository
@@ -39,8 +39,8 @@ jobs:
       - name: Compile code
         run: npm run compile
 
-      # - name: Lint
-      #   run: npm run lint
+      - name: Lint
+        run: npm run lint
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -109,35 +109,10 @@ jobs:
           APPLE_API_KEY: ~/private_keys/AuthKey_${{ env.APPLE_API_KEY_ID }}.p8
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }}
 
-      # - name: Look around
-      #   run: |
-      #     pwd
-      #     ls D:\a\swivvel-electron\swivvel-electron\
-      #     echo "++++++++++++++++++++++"
-      #     ls D:\a\swivvel-electron\swivvel-electron\dist
-      #     echo "++++++++++++++++++++++"
-      #     ls D:\a\swivvel-electron\swivvel-electron\dist\win-unpacked
-
-      # - name: Signing using Signtool
-      #   if: startsWith(matrix.os, 'windows')
-      #   run: |
-      #     signtool.exe sign /sha1 ${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "D:\a\swivvel-electron\swivvel-electron\dist\Swivvel-win.exe"
-      #     signtool.exe verify /v /pa "D:\a\swivvel-electron\swivvel-electron\dist\Swivvel-win.exe"
-
-      # - name: Upload artifacts
-      #   if: startsWith(matrix.os, 'windows')
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: ${{ matrix.os }}
-      #     path: |
-      #       dist/Swivvel-win.exe
-      #       dist/Swivvel-win.exe.blockmap
-      #       dist/latest.yml
-
-    # - name: Print notarization error log
-    #   if: startsWith(matrix.os, 'macos') && steps.build.outcome == 'failure'
-    #   run: |
-    #     if [ -f "notarization-error.log" ]; then
-    #       cat notarization-error.log
-    #     fi
-    #     exit 1
+      - name: Print notarization error log
+        if: startsWith(matrix.os, 'macos') && steps.build.outcome == 'failure'
+        run: |
+          if [ -f "notarization-error.log" ]; then
+            cat notarization-error.log
+          fi
+          exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,17 +54,10 @@ jobs:
           mkdir -p ~/private_keys/
           echo '${{ env.APPLE_API_KEY }}' > ~/private_keys/AuthKey_${{ env.APPLE_API_KEY_ID }}.p8
 
-      - name: Setup Windows Signing Certificate
+      - name: Setup Windows Signing Certificate and set env variables
         if: startsWith(matrix.os, 'windows')
         run: |
           echo "${{ env.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
-          cat  /d/Certificate_pkcs12.p12
-        shell: bash
-
-      - name: Set variables
-        if: startsWith(matrix.os, 'windows')
-        id: variables
-        run: |
           echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
           echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       MAC_CERTS_PASSWORD: ${{ secrets.MAC_CERTS_PASSWORD }}
       MAC_CERTS: ${{ secrets.MAC_CERTS }}
+      SM_API_KEY: ${{ secrets.SM_API_KEY }}
+      SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
+      SM_CLIENT_CERT_FILE_B64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+      SM_CLIENT_CERT_PASSWORD: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
+      SM_HOST: ${{ secrets.SM_HOST }}
       SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_TOKEN }}
 
     strategy:
@@ -49,6 +54,33 @@ jobs:
           mkdir -p ~/private_keys/
           echo '${{ env.APPLE_API_KEY }}' > ~/private_keys/AuthKey_${{ env.APPLE_API_KEY_ID }}.p8
 
+      - name: Setup Windows Signing Certificate and set env variables
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          echo "${{ env.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+          echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
+          echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
+          echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+          echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+          echo "C:\Program Files\DigiCert\DigiCert Keylocker Tools" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Setup Keylocker KSP on windows
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/Keylockertools-windows-x64.msi/download -H "x-api-key:%SM_API_KEY%" -o Keylockertools-windows-x64.msi
+          msiexec /i Keylockertools-windows-x64.msi /quiet /qn
+          smksp_registrar.exe list
+          smctl.exe keypair ls
+          C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+        shell: cmd
+
+      - name: Certificates Sync
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          smctl windows certsync
+        shell: cmd
+
       - name: Build/release Electron app
         id: build
         uses: samuelmeuli/action-electron-builder@v1
@@ -62,12 +94,13 @@ jobs:
 
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building
-          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          release: true # ${{ startsWith(github.ref, 'refs/tags/v') }}
         env:
           # MacOS notarization API key
           APPLE_API_KEY_ID: ${{ env.APPLE_API_KEY_ID }}
           APPLE_API_KEY_ISSUER: ${{ env.APPLE_API_KEY_ISSUER }}
           APPLE_API_KEY: ~/private_keys/AuthKey_${{ env.APPLE_API_KEY_ID }}.p8
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }}
 
       - name: Print notarization error log
         if: startsWith(matrix.os, 'macos') && steps.build.outcome == 'failure'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [windows-latest]
 
     steps:
       - name: Check out Git repository
@@ -39,8 +39,8 @@ jobs:
       - name: Compile code
         run: npm run compile
 
-      - name: Lint
-        run: npm run lint
+      # - name: Lint
+      #   run: npm run lint
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v2
@@ -54,10 +54,17 @@ jobs:
           mkdir -p ~/private_keys/
           echo '${{ env.APPLE_API_KEY }}' > ~/private_keys/AuthKey_${{ env.APPLE_API_KEY_ID }}.p8
 
-      - name: Setup Windows Signing Certificate and set env variables
+      - name: Setup Windows Signing Certificate
         if: startsWith(matrix.os, 'windows')
         run: |
           echo "${{ env.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+          cat  /d/Certificate_pkcs12.p12
+        shell: bash
+
+      - name: Set variables
+        if: startsWith(matrix.os, 'windows')
+        id: variables
+        run: |
           echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_ENV"
           echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
@@ -102,10 +109,35 @@ jobs:
           APPLE_API_KEY: ~/private_keys/AuthKey_${{ env.APPLE_API_KEY_ID }}.p8
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }}
 
-      - name: Print notarization error log
-        if: startsWith(matrix.os, 'macos') && steps.build.outcome == 'failure'
-        run: |
-          if [ -f "notarization-error.log" ]; then
-            cat notarization-error.log
-          fi
-          exit 1
+      # - name: Look around
+      #   run: |
+      #     pwd
+      #     ls D:\a\swivvel-electron\swivvel-electron\
+      #     echo "++++++++++++++++++++++"
+      #     ls D:\a\swivvel-electron\swivvel-electron\dist
+      #     echo "++++++++++++++++++++++"
+      #     ls D:\a\swivvel-electron\swivvel-electron\dist\win-unpacked
+
+      # - name: Signing using Signtool
+      #   if: startsWith(matrix.os, 'windows')
+      #   run: |
+      #     signtool.exe sign /sha1 ${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "D:\a\swivvel-electron\swivvel-electron\dist\Swivvel-win.exe"
+      #     signtool.exe verify /v /pa "D:\a\swivvel-electron\swivvel-electron\dist\Swivvel-win.exe"
+
+      # - name: Upload artifacts
+      #   if: startsWith(matrix.os, 'windows')
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: ${{ matrix.os }}
+      #     path: |
+      #       dist/Swivvel-win.exe
+      #       dist/Swivvel-win.exe.blockmap
+      #       dist/latest.yml
+
+    # - name: Print notarization error log
+    #   if: startsWith(matrix.os, 'macos') && steps.build.outcome == 'failure'
+    #   run: |
+    #     if [ -f "notarization-error.log" ]; then
+    #       cat notarization-error.log
+    #     fi
+    #     exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
 
           # If the commit is tagged with a version (e.g. "v1.0.0"),
           # release the app after building
-          release: true # ${{ startsWith(github.ref, 'refs/tags/v') }}
+          release: ${{ startsWith(github.ref, 'refs/tags/v') }}
         env:
           # MacOS notarization API key
           APPLE_API_KEY_ID: ${{ env.APPLE_API_KEY_ID }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swivvel",
   "productName": "Swivvel",
-  "version": "1.2.21",
+  "version": "1.0.998",
   "author": {
     "name": "Swivvel",
     "email": "support@swivvel.io"
@@ -42,7 +42,8 @@
     },
     "win": {
       "artifactName": "${productName}-win.${ext}",
-      "icon": "build/icon.ico"
+      "icon": "build/icon.ico",
+      "sign": "./signWindows.js"
     },
     "linux": {
       "icon": "build/icon.icns",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swivvel",
   "productName": "Swivvel",
-  "version": "1.0.998",
+  "version": "1.2.21",
   "author": {
     "name": "Swivvel",
     "email": "support@swivvel.io"

--- a/signWindows.js
+++ b/signWindows.js
@@ -1,0 +1,14 @@
+exports.default = async (configuration) => {
+  const execSync = require('child_process').execSync;
+
+  const getEnv = (name) => process.env[name.toUpperCase()] || null;
+  const signingHash = getEnv(`SM_CODE_SIGNING_CERT_SHA1_HASH`);
+
+  const file = configuration.path;
+
+  const signCmd = `signtool.exe sign /sha1 ${signingHash} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "${file}"`;
+  console.log(execSync(signCmd).toString());
+
+  const verifyCmd = `signtool.exe verify /v /pa "${file}"`;
+  console.log(execSync(verifyCmd).toString());
+};


### PR DESCRIPTION
## The Problem

If we don't sign our windows code, the user will have to jump through a bunch of hoops when they download the app. Plus our product seems very illegitimate:


https://github.com/swivvel/swivvel-electron/assets/131678810/ec7d4a2b-bec4-451f-a3fd-ad7fb241e3a6


## The Solution

We should sign our windows app. We do this, we purchased a Code Signing Certificate form Digicert. Due to [new regulations](https://knowledge.digicert.com/generalinformation/new-private-key-storage-requirement-for-standard-code-signing-certificates-november-2022.html), signing keys need to be stored on certain hardware. In order for us to satisfy that requirement, our key will be hosted by Digicert in our [Digicert One Keylocker](https://one.digicert.com/).

As a part of our build process, we can use a secret API to access our certificate without needing to store the cert itself outside of Keylocker. 

This solution was largely lifted from here: https://docs.digicert.com/en/digicert-keylocker/ci-cd-integrations/plugins/github-custom-action-for-keypair-signing.html

The env vars we need for the process are:

Key | Val
-- | --
SM_CLIENT_CERT_PASSWORD | Insert the password that you were shown when you created your client authentication certificate in Digicert One.
SM_CLIENT_CERT_FILE_B64 | Insert the base64 encoded string of your client authentication certificate that you created in Digicert One.
SM_HOST | The path to the DigiCert ONE portal with client authorization.  The SM_HOST value you use depends on whether you are using demo or prod. For assistance, refer to [host environment](https://docs.digicert.com/en/software-trust-manager/general/requirements.html#host-environment-565736).
SM_API_KEY | The API token created in Digicert ONE.
SM_CODE_SIGNING_CERT_SHA1_HASH | The certificate fingerprint, shown in KeyLocker.


## Testing


https://github.com/swivvel/swivvel-electron/assets/131678810/7d200808-17ab-4ba4-af15-63454ebcc561


