### PR TITLE
Allow building windows code locally without signing

### DIFF
--- a/signWindows.js
+++ b/signWindows.js
@@ -4,6 +4,11 @@ exports.default = async (configuration) => {
   const getEnv = (name) => process.env[name.toUpperCase()] || null;
   const signingHash = getEnv(`SM_CODE_SIGNING_CERT_SHA1_HASH`);
 
+  if (!signingHash) {
+    console.log(`No signing hash found, skipping code signing.`);
+    return;
+  }
+
   const file = configuration.path;
 
   const signCmd = `signtool.exe sign /sha1 ${signingHash} /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 "${file}"`;


### PR DESCRIPTION
Noticed when running a test build for windows that the local build was failing because it didnt have the  necessary code signing setup. This skips the code signing bit if the prereqs arent in place