### PR TITLE
Unregister mousemove when transparent window destroyed

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -5,6 +5,7 @@ import configureApp from './configureApp';
 import configureAppQuitHandling from './configureAppQuitHandling';
 import configureAutoUpdates from './configureAutoUpdates';
 import configureIpcHandlers from './configureIpcHandlers';
+import configureMousePassThroughHandler from './configureMousePassThroughHandler';
 import configureSentry from './configureSentry';
 import getDeepLinkHandler from './getDeepLinkHandler';
 import handlePowerMonitorStateChanges from './handlePowerMonitorStateChanges';
@@ -57,6 +58,7 @@ const run = async (): Promise<void> => {
   // transparent window loads
   configureIpcHandlers(windowService);
   pollForIdleTime(state);
+  configureMousePassThroughHandler(state);
 
   await windowService.openTransparentWindow();
 

--- a/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
+++ b/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
@@ -51,6 +51,9 @@ export default (transparentWindow: BrowserWindow): void => {
 
     const handler = (event: unknown, isOverTransparency: boolean): void => {
       if (transparentWindow.isDestroyed()) {
+        log.info(
+          `Transparent window destroyed: unregistering mouse pass-through handler`
+        );
         ipcMain.off(`onMouseOverTransparentArea`, handler);
         return;
       }

--- a/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
+++ b/src/background/useWindowService/openTransparentWindow/configureMousePassThroughHandler.ts
@@ -49,22 +49,26 @@ export default (transparentWindow: BrowserWindow): void => {
 
     let isOverTransparencyPrevious: boolean | null = null;
 
-    ipcMain.on(
-      `onMouseOverTransparentArea`,
-      (event, isOverTransparency: boolean): void => {
-        transparentWindow.setIgnoreMouseEvents(isOverTransparency, {
-          forward: true,
-        });
-
-        if (isOverTransparency !== isOverTransparencyPrevious) {
-          log.info(
-            `Mouse is over transparent: ${isOverTransparencyPrevious} -> ${isOverTransparency}`
-          );
-        }
-
-        isOverTransparencyPrevious = isOverTransparency;
+    const handler = (event: unknown, isOverTransparency: boolean): void => {
+      if (transparentWindow.isDestroyed()) {
+        ipcMain.off(`onMouseOverTransparentArea`, handler);
+        return;
       }
-    );
+
+      transparentWindow.setIgnoreMouseEvents(isOverTransparency, {
+        forward: true,
+      });
+
+      if (isOverTransparency !== isOverTransparencyPrevious) {
+        log.info(
+          `Mouse is over transparent: ${isOverTransparencyPrevious} -> ${isOverTransparency}`
+        );
+      }
+
+      isOverTransparencyPrevious = isOverTransparency;
+    };
+
+    ipcMain.on(`onMouseOverTransparentArea`, handler);
 
     return;
   }

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -2,7 +2,6 @@ import { getSiteUrl, isLinux, loadUrl, sleep } from '../../utils';
 import { openBrowserWindow } from '../utils';
 
 import configureCloseHandler from './configureCloseHandler';
-import configureMousePassThroughHandler from './configureMousePassThroughHandler';
 import getLogger from './getLogger';
 import getTransparentBrowserWindowOptions from './getTransparentBrowserWindowOptions';
 import resizeOnDisplayChange from './resizeOnDisplayChange';
@@ -16,6 +15,8 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
   const options = getTransparentBrowserWindowOptions();
 
   return openBrowserWindow(state, `transparent`, options, async (window) => {
+    window.setIgnoreMouseEvents(true, { forward: true });
+
     // Prevent the transparent window from appearing in screenshots
     // See: https://www.electronjs.org/docs/latest/api/browser-window#winsetcontentprotectionenable-macos-windows
     window.setContentProtection(true);
@@ -45,7 +46,6 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
 
     showOnAllWorkspaces(window);
     configureCloseHandler(window, state);
-    configureMousePassThroughHandler(window, state);
     resizeOnDisplayChange(window);
 
     await loadUrl(`${getSiteUrl()}/notifications`, window, state, {

--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -45,7 +45,7 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
 
     showOnAllWorkspaces(window);
     configureCloseHandler(window, state);
-    configureMousePassThroughHandler(window);
+    configureMousePassThroughHandler(window, state);
     resizeOnDisplayChange(window);
 
     await loadUrl(`${getSiteUrl()}/notifications`, window, state, {


### PR DESCRIPTION
## The Problem

In commit 01aaef242b92feb25853d16e87ec424f4ae22d44, we updated our transparent window mouse pass-through strategy for Macs to use a `mousemove` handler. However, we forgot to check whether the transparent window has been destroyed before calling `transparentWindow.setIgnoreMouseEvents()`, so now some users are getting the [following error](https://swivvel.sentry.io/issues/4554113703/?project=4504796469657600&query=is%3Aunresolved&referrer=issue-stream&stream_index=0):

> TypeError: Object has been destroyed

## The Solution

Unregister the `mousemove` handler when the transparent window is destroyed.