### PR TITLE
Improve login flow in Google meet window

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -31,6 +31,7 @@ const run = async (): Promise<void> => {
 
   const state: State = {
     allowQuit: false,
+    loggedInUser: null,
     logInFlowCompleted: false,
     tray: null,
     windows: {
@@ -54,7 +55,7 @@ const run = async (): Promise<void> => {
 
   // These functions set up IPC handlers that must be registered before the
   // transparent window loads
-  configureIpcHandlers(windowService);
+  configureIpcHandlers(windowService, state);
   pollForIdleTime(state);
   configureMousePassThroughHandler(state);
 

--- a/src/background/configureIpcHandlers.ts
+++ b/src/background/configureIpcHandlers.ts
@@ -4,10 +4,11 @@ import log from 'electron-log';
 
 import { ShareableMediaSource } from '../types';
 
+import { State } from './types';
 import { WindowService } from './useWindowService';
 import { getShareableMediaSources, isProduction } from './utils';
 
-export default (windowService: WindowService): void => {
+export default (windowService: WindowService, state: State): void => {
   ipcMain.handle(`getDesktopAppVersion`, () => {
     return app.getVersion();
   });
@@ -48,6 +49,8 @@ export default (windowService: WindowService): void => {
       log.info(`Received identifyUser event, user=${JSON.stringify(user)}`);
       log.info(`Setting Sentry user context`);
       Sentry.setUser(user ? { ...user, email: user.email || undefined } : null);
+      log.info(`Updating electron state`);
+      state.loggedInUser = user ? user : null;
     }
   );
 

--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -8,6 +8,14 @@ export interface State {
   allowQuit: boolean;
 
   /**
+   * Info about the logged in user, if any.
+   */
+  loggedInUser: {
+    email: string | null;
+    id: string;
+  } | null;
+
+  /**
    * True if the user has completed the log in flow and is authenticated.
    */
   logInFlowCompleted: boolean;

--- a/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
@@ -15,6 +15,7 @@ import pollForJoinAndLeaveEvents from './pollForJoinAndLeaveEvents';
 import scrapeAndSaveMeetingUrl from './scrapeAndSaveMeetingUrl';
 import triggerMeetingCreatedEvent from './triggerMeetingCreatedEvent';
 import { OpenGoogleMeetWindow } from './types';
+import patchLoginFlow from './patchLoginFlow';
 
 const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
   const { podId, meetingUrl, state, windowOpenRequestHandler } = args;
@@ -62,6 +63,9 @@ const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
     await loadMeetingUrl(meetingUrlToOpen, window, state, log);
 
     await patchGetDisplayMediaOnUrlChange(window, log);
+
+    await patchLoginFlow(window, log);
+
     // The get-a-link window will try to resize itself to be small, so we
     // need to create the window with a minimum size equal to the desired
     // size. Once we've loaded the meeting we can lower the minimum size

--- a/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
@@ -11,11 +11,11 @@ import configureCloseHandler from './configureCloseHandler';
 import getBrowserWindowOptions from './getBrowserWindowOptions';
 import loadMeetingUrl from './loadMeetingUrl';
 import patchGetDisplayMediaOnUrlChange from './patchGetDisplayMediaOnUrlChange';
+import patchLoginFlow from './patchLoginFlow';
 import pollForJoinAndLeaveEvents from './pollForJoinAndLeaveEvents';
 import scrapeAndSaveMeetingUrl from './scrapeAndSaveMeetingUrl';
 import triggerMeetingCreatedEvent from './triggerMeetingCreatedEvent';
 import { OpenGoogleMeetWindow } from './types';
-import patchLoginFlow from './patchLoginFlow';
 
 const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
   const { podId, meetingUrl, state, windowOpenRequestHandler } = args;

--- a/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
@@ -38,6 +38,8 @@ const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
       await systemPreferences.askForMediaAccess(`camera`);
     }
 
+    await patchLoginFlow(window, state, log);
+
     if (!meetingUrlToOpen) {
       await loadUrl(`https://meet.google.com/getalink`, window, state, log, {
         // Since the Google Meet window is opened from a user action, we must
@@ -63,8 +65,6 @@ const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
     await loadMeetingUrl(meetingUrlToOpen, window, state, log);
 
     await patchGetDisplayMediaOnUrlChange(window, log);
-
-    await patchLoginFlow(window, log);
 
     // The get-a-link window will try to resize itself to be small, so we
     // need to create the window with a minimum size equal to the desired

--- a/src/background/useWindowService/openGoogleMeetWindow/patchGetDisplayMediaOnUrlChange/patchGetDisplayMedia/patchGetDisplayMedia.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchGetDisplayMediaOnUrlChange/patchGetDisplayMedia/patchGetDisplayMedia.ts
@@ -1,26 +1,23 @@
-import fs from 'fs';
 import path from 'path';
 
 import { BrowserWindow } from 'electron';
 
-import { Log } from '../../../utils';
+import { Log, loadRawJsFromFile } from '../../../utils';
 
 export default async (meetWindow: BrowserWindow, log: Log): Promise<void> => {
   log(`Patching getDisplayMedia...`);
 
-  const filesContents = fs.readFileSync(
-    path.join(__dirname, `getDisplayMedia.js`),
-    `utf-8`
+  const fileContents = loadRawJsFromFile(
+    path.join(__dirname, `getDisplayMedia.js`)
   );
-  const matches = filesContents.match(/(async [\S\s]*);/);
 
-  if (!matches) {
+  if (!fileContents) {
     throw new Error(`Could not find contents of getDisplayMedia.js`);
   }
 
   // The && 'force' is needed to prevent the following error:
   // UnhandledPromiseRejectionWarning: Error: An object could not be cloned.
-  const patchCommand = `(window.navigator.mediaDevices.getDisplayMedia = ${matches[1]}) && 'force'`;
+  const patchCommand = `(window.navigator.mediaDevices.getDisplayMedia = ${fileContents}) && 'force'`;
 
   await meetWindow.webContents.executeJavaScript(patchCommand);
 };

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/addBannerToLoginFlow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/addBannerToLoginFlow.ts
@@ -1,0 +1,27 @@
+import path from 'path';
+
+import { BrowserWindow } from 'electron';
+
+import { Log, loadRawJsFromFile } from '../../../utils';
+
+export default async (window: BrowserWindow, log: Log): Promise<boolean> => {
+  if (!window.webContents.getURL().includes(`https://accounts.google.com/`)) {
+    log(`User is not in the login flow`);
+    return false;
+  }
+
+  log(`Adding banner to login flow...`);
+
+  const insertBannerJs = loadRawJsFromFile(
+    path.join(__dirname, `insertBanner.js`)
+  );
+
+  if (!insertBannerJs) {
+    log(`Could not find contents of insertBanner.js`);
+    return false;
+  }
+
+  window.webContents.executeJavaScript(`(${insertBannerJs})()`);
+
+  return true;
+};

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/addBannerToLoginFlow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/addBannerToLoginFlow.ts
@@ -6,7 +6,7 @@ import { Log, loadRawJsFromFile } from '../../../utils';
 
 export default async (window: BrowserWindow, log: Log): Promise<boolean> => {
   if (!window.webContents.getURL().includes(`https://accounts.google.com/`)) {
-    log(`User is not in the login flow`);
+    log(`User is not in the login flow, cannot add banner`);
     return false;
   }
 

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/index.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/index.ts
@@ -1,0 +1,3 @@
+import addBannerToLoginFlow from './addBannerToLoginFlow';
+
+export default addBannerToLoginFlow;

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/insertBanner.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/insertBanner.ts
@@ -35,7 +35,7 @@ async (): Promise<void> => {
   }
 
   .sign-in-flow-banner__header {
-    font-weight: 500;
+    font-weight: bold;
     margin-right: 40px;
   }
 

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/insertBanner.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/addBannerToLoginFlow/insertBanner.ts
@@ -1,0 +1,75 @@
+async (): Promise<void> => {
+  // This file _MUST_ contain just one top level function to be
+  // executed in the google meet window
+
+  // If we try to set the innerHTML of an element, we get an error saying
+  // that the string is not trusted. We can get around this by creating a
+  // trusted type policy that allows us to create HTML from a string.
+  // See: https://developer.mozilla.org/en-US/docs/Web/API/TrustedHTML
+  const escapeHTMLPolicy = window.trustedTypes.createPolicy(`forceInner`, {
+    createHTML: (toEscape: string) => {
+      return toEscape;
+    },
+  });
+
+  const screenShareStyles = document.createElement(`style`);
+  screenShareStyles.innerHTML = escapeHTMLPolicy.createHTML(`
+  .sign-in-flow-banner {
+    background: #c4e0e7;
+    position: absolute;
+    top: 0px;
+    width: 100%;
+    z-index: 1;
+  }
+
+  .sign-in-flow-banner__container {
+    display: flex;
+    justify-content: center;
+    padding: 30px;
+  }
+
+  .sign-in-flow-banner__content {
+    display: flex;
+    flex-grow: 1;
+    justify-content: center;
+  }
+
+  .sign-in-flow-banner__header {
+    font-weight: 500;
+    margin-right: 40px;
+  }
+
+  .sign-in-flow-banner__corner {
+    flex: 1;
+  }
+
+  .sign-in-flow-banner__close {
+    cursor: pointer;
+    text-align: end;
+  }
+  `);
+
+  document.head.appendChild(screenShareStyles);
+
+  const selectionElem = document.createElement(`div`);
+  selectionElem.classList.add(`sign-in-flow-banner`);
+  selectionElem.innerHTML = escapeHTMLPolicy.createHTML(`
+    <div class="sign-in-flow-banner__container">
+      <div class="sign-in-flow-banner__corner"></div>
+      <div class="sign-in-flow-banner__content">
+        <div class="sign-in-flow-banner__header">Connect Google Meet</div>
+        <div>Sign in to your Google account to connect Google Meet and create / join meetings.</div>
+      </div>
+      <div class="sign-in-flow-banner__corner sign-in-flow-banner__close">X</div>
+    </div>
+`);
+
+  document.body.appendChild(selectionElem);
+
+  const closeBtn = document.querySelector(`.sign-in-flow-banner__close`);
+  if (closeBtn) {
+    closeBtn.addEventListener(`click`, () => {
+      selectionElem.remove();
+    });
+  }
+};

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/clickSignInIfInLobby.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/clickSignInIfInLobby.ts
@@ -1,0 +1,32 @@
+import { BrowserWindow } from 'electron';
+
+import { Log } from '../../utils';
+
+export default async (window: BrowserWindow, log: Log): Promise<boolean> => {
+  if (!window.webContents.getURL().includes(`https://meet.google.com/`)) {
+    log(`User is not in a Google Meet (or its lobby)`);
+    return false;
+  }
+
+  const clickedSignIn = await window.webContents.executeJavaScript(`
+  (() => {
+    const signInButton = [...document.querySelectorAll('[role="button"]')].find((button) => {
+      return [...button.querySelectorAll('span')].find((span) => {
+        return span.innerText.toLowerCase().includes('sign in');
+      })
+    }) || null;
+
+    if (signInButton) {
+      signInButton.click();
+    }
+
+    return Boolean(signInButton);
+  })();
+  `);
+
+  if (clickedSignIn) {
+    log(`Clicked sign in button`);
+  }
+
+  return clickedSignIn;
+};

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/index.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/index.ts
@@ -1,0 +1,3 @@
+import patchLoginFlow from './patchLoginFlow';
+
+export default patchLoginFlow;

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/patchLoginFlow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/patchLoginFlow.ts
@@ -4,6 +4,7 @@ import { Log } from '../../utils';
 
 import addBannerToLoginFlow from './addBannerToLoginFlow';
 import clickSignInIfInLobby from './clickSignInIfInLobby';
+import prefillEmailAndAdvance from './prefillEmailAndAdvance';
 
 export default async (window: BrowserWindow, log: Log): Promise<void> => {
   log(`Patching login flow...`);
@@ -12,6 +13,8 @@ export default async (window: BrowserWindow, log: Log): Promise<void> => {
     await clickSignInIfInLobby(window, log);
 
     await addBannerToLoginFlow(window, log);
+
+    await prefillEmailAndAdvance(window, log);
   };
 
   await patchLoginFlow();

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/patchLoginFlow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/patchLoginFlow.ts
@@ -1,25 +1,38 @@
 import { BrowserWindow } from 'electron';
 
+import { State } from '../../../types';
 import { Log } from '../../utils';
 
 import addBannerToLoginFlow from './addBannerToLoginFlow';
 import clickSignInIfInLobby from './clickSignInIfInLobby';
 import prefillEmailAndAdvance from './prefillEmailAndAdvance';
 
-export default async (window: BrowserWindow, log: Log): Promise<void> => {
+export default async (
+  window: BrowserWindow,
+  state: State,
+  log: Log
+): Promise<void> => {
   log(`Patching login flow...`);
 
   const patchLoginFlow = async (): Promise<void> => {
+    // If the user is in the lobby and not signed in, click the sign in button
+    // for them
     await clickSignInIfInLobby(window, log);
 
+    // If the user is in the google login flow, add a banner explaining why
+    // they need to connect
     await addBannerToLoginFlow(window, log);
 
-    await prefillEmailAndAdvance(window, log);
+    // If the user is prompted to input their email and we know their email,
+    // enter it for them and advance to the next step
+    await prefillEmailAndAdvance(window, state, log);
   };
 
   await patchLoginFlow();
 
   window.webContents.on(`did-finish-load`, async () => {
+    // Run the patch again if the page reloads or the user is taken to another
+    // page (e.g. login page)
     await patchLoginFlow();
   });
 };

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/patchLoginFlow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/patchLoginFlow.ts
@@ -1,0 +1,22 @@
+import { BrowserWindow } from 'electron';
+
+import { Log } from '../../utils';
+
+import addBannerToLoginFlow from './addBannerToLoginFlow';
+import clickSignInIfInLobby from './clickSignInIfInLobby';
+
+export default async (window: BrowserWindow, log: Log): Promise<void> => {
+  log(`Patching login flow...`);
+
+  const patchLoginFlow = async (): Promise<void> => {
+    await clickSignInIfInLobby(window, log);
+
+    await addBannerToLoginFlow(window, log);
+  };
+
+  await patchLoginFlow();
+
+  window.webContents.on(`did-finish-load`, async () => {
+    await patchLoginFlow();
+  });
+};

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/prefillEmailAndAdvance.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/prefillEmailAndAdvance.ts
@@ -1,0 +1,51 @@
+import { BrowserWindow } from 'electron';
+
+import { Log } from '../../utils';
+
+export default async (window: BrowserWindow, log: Log): Promise<boolean> => {
+  if (!window.webContents.getURL().includes(`https://accounts.google.com/`)) {
+    log(`User is not in the login flow, cannot prefill email`);
+    return false;
+  }
+
+  const email = `eric@swivvel.io`;
+
+  const prefilled = await window.webContents.executeJavaScript(`
+  (() => {
+    const emailInput = document.querySelector('input[type="email"]');
+
+    if (emailInput) {
+      emailInput.value = '${email}';
+      // Remove siblings of email input to get rid of placeholder text
+      [...emailInput.parentElement.children].forEach((child) => {
+        if (child !== emailInput) {
+          child.remove()
+        }
+      })
+    }
+
+    return Boolean(emailInput);
+  })();
+  `);
+
+  if (prefilled) {
+    log(`Prefilled email`);
+  } else {
+    log(`Could not find email input`);
+    return false;
+  }
+
+  const advanced = await window.webContents.executeJavaScript(`
+  (() => {
+    const nextButton = document.querySelector('#identifierNext');
+
+    if (nextButton) {
+      nextButton.click()
+    }
+
+    return Boolean(nextButton);
+  })();
+  `);
+
+  return advanced;
+};

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/prefillEmailAndAdvance.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/prefillEmailAndAdvance.ts
@@ -1,14 +1,24 @@
 import { BrowserWindow } from 'electron';
 
+import { State } from '../../../types';
 import { Log } from '../../utils';
 
-export default async (window: BrowserWindow, log: Log): Promise<boolean> => {
+export default async (
+  window: BrowserWindow,
+  state: State,
+  log: Log
+): Promise<boolean> => {
+  const email = state.loggedInUser?.email;
+
+  if (!email) {
+    log(`No email to prefill`);
+    return false;
+  }
+
   if (!window.webContents.getURL().includes(`https://accounts.google.com/`)) {
     log(`User is not in the login flow, cannot prefill email`);
     return false;
   }
-
-  const email = `eric@swivvel.io`;
 
   const prefilled = await window.webContents.executeJavaScript(`
   (() => {

--- a/src/background/useWindowService/utils/index.ts
+++ b/src/background/useWindowService/utils/index.ts
@@ -1,7 +1,13 @@
 import closeBrowserWindow from './closeBrowserWindow';
 import getBrowserWindowLogger, { Log } from './getBrowserWindowLogger';
+import loadRawJsFromFile from './loadRawJsFromFile';
 import openBrowserWindow, { InstantiateWindow } from './openBrowserWindow';
 
 export type { InstantiateWindow, Log };
 
-export { closeBrowserWindow, getBrowserWindowLogger, openBrowserWindow };
+export {
+  closeBrowserWindow,
+  getBrowserWindowLogger,
+  loadRawJsFromFile,
+  openBrowserWindow,
+};

--- a/src/background/useWindowService/utils/loadRawJsFromFile.ts
+++ b/src/background/useWindowService/utils/loadRawJsFromFile.ts
@@ -1,0 +1,13 @@
+import fs from 'fs';
+
+export default (filePath: string): string | null => {
+  const fileContents = fs.readFileSync(filePath, `utf-8`);
+
+  const regexMatches = fileContents.match(/(async [\S\s]*);/);
+
+  if (!regexMatches) {
+    return null;
+  }
+
+  return regexMatches[1];
+};


### PR DESCRIPTION
## The Problem

The first time that a user opens a google meet, they will be prompted to log in because we dont have their google session in electron. This could be confusing, especially if the user does not know that they need to sign in.

## The Solution

Three big pieces we can automate here:
1) If a user is in the waiting room for a meeting and they aren't signed in, we can auto-click the sign in button for them
2) We can add a banner to the sign in flow explaining why they need to connect
3) We can auto-populate the email address and advance to the next step for the user


## Testing

If breakout room doesnt yet exist...

https://github.com/swivvel/swivvel-electron/assets/131678810/94d6252e-3812-4a0d-8f53-7ce75abe3550

If breakout room already exists....

https://github.com/swivvel/swivvel-electron/assets/131678810/5afab23d-a96d-4d65-9ef0-a23c0fcc08ef


If user is already logged in (nothing changes)

https://github.com/swivvel/swivvel-electron/assets/131678810/4d777f10-cae5-4c2d-9171-c639d6908ce7


