### PR TITLE
Add "menu option" to sent bug report dialog

### DIFF
--- a/src/background/useTrayService/utils/getBaseMenuItems.ts
+++ b/src/background/useTrayService/utils/getBaseMenuItems.ts
@@ -44,7 +44,7 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
       });
       dialog.showErrorBox(
         `Bug Report Sent`,
-        `Thanks for sending. If you haven't already, please use the Chat Support to send us a screenshot and a quick description.`
+        `Thanks for sending. If you haven't already, please use the Chat Support menu option to send us a screenshot and a quick description.`
       );
     },
   });


### PR DESCRIPTION
## The Problem
The previous wording for the Sent Bug Report dialog was
> please use the Chat Support to

Which sounded a bit off

## The Solution
Update to 
> please use the Chat Support menu option to
