### PR TITLE
Update message for users triggered for users

### DIFF
--- a/src/background/configureIpcHandlers.ts
+++ b/src/background/configureIpcHandlers.ts
@@ -83,7 +83,7 @@ export default (windowService: WindowService, state: State): void => {
 
   ipcMain.on(`triggerSentryError`, async (): Promise<void> => {
     log.info(`Received triggerSentryError event`);
-    triggerSentryError();
+    triggerSentryError(`Error triggered for user`);
     log.info(`Triggering Sentry error`);
   });
 };

--- a/src/background/useTrayService/utils/getBaseMenuItems.ts
+++ b/src/background/useTrayService/utils/getBaseMenuItems.ts
@@ -35,7 +35,7 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
       log.info(
         `Detected click on Send Bug Report menu item; sending Sentry alert`
       );
-      triggerSentryError();
+      triggerSentryError(`Manual bug report`);
       dialog.showErrorBox(
         `Bug Report Sent`,
         `Thanks for sending. If you haven't already, please use the Chat Support menu option to send us a screenshot and a quick description.`

--- a/src/background/utils/triggerSentryError.ts
+++ b/src/background/utils/triggerSentryError.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/electron/main';
 import { v4 as uuidv4 } from 'uuid';
 
-export default (): void => {
+export default (errorMessage: string): void => {
   Sentry.withScope((scope) => {
     // Use a unique fingerprint to avoid grouping in Sentry so that we
     // don't accidentally miss an alert about a manual bug report
@@ -9,7 +9,7 @@ export default (): void => {
 
     const userEmail = scope.getUser()?.email || `no user`;
     const now = new Date().toISOString();
-    const message = `Manual bug report - ${userEmail} - ${now}`;
+    const message = `${errorMessage} - ${userEmail} - ${now}`;
     Sentry.captureException(new Error(message));
   });
 };


### PR DESCRIPTION
## The Problem

We can now trigger an error on behalf of a user, but we need a way to differentiate those from manually reported errors.

## The Solution

Make the error message configurable 

