### PR TITLE
Check meet window hasnt been destroyed before executing js

### DIFF
--- a/src/background/useWindowService/openGoogleMeetWindow/patchGetDisplayMediaOnUrlChange/patchGetDisplayMedia/patchGetDisplayMedia.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchGetDisplayMediaOnUrlChange/patchGetDisplayMedia/patchGetDisplayMedia.ts
@@ -15,6 +15,11 @@ export default async (meetWindow: BrowserWindow, log: Log): Promise<void> => {
     throw new Error(`Could not find contents of getDisplayMedia.js`);
   }
 
+  if (meetWindow.isDestroyed()) {
+    log(`Google Meet window destroyed; not patching getDisplayMedia`);
+    return;
+  }
+
   // The && 'force' is needed to prevent the following error:
   // UnhandledPromiseRejectionWarning: Error: An object could not be cloned.
   const patchCommand = `(window.navigator.mediaDevices.getDisplayMedia = ${fileContents}) && 'force'`;

--- a/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/patchLoginFlow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/patchLoginFlow/patchLoginFlow.ts
@@ -15,6 +15,11 @@ export default async (
   log(`Patching login flow...`);
 
   const patchLoginFlow = async (): Promise<void> => {
+    if (window.isDestroyed()) {
+      log(`Google Meet window destroyed; not patching login flow`);
+      return;
+    }
+
     // If the user is in the lobby and not signed in, click the sign in button
     // for them
     await clickSignInIfInLobby(window, log);


### PR DESCRIPTION
## The Problem

We got a Sentry error where we tried to execute some javascript inside the google meet window, but the window had been destroyed.

## The Solution

We should check that the window is still hanging around before trying to execute anything in it
