### PR TITLE
Ignore auto-update errors; increase update poll to 30 minutes

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -62,8 +62,8 @@ const run = async (): Promise<void> => {
   await windowService.openTransparentWindow();
 
   trayService.createTray();
-  configureAutoUpdates(state);
   handlePowerMonitorStateChanges(state, windowService);
+  await configureAutoUpdates(state);
 
   log.info(`App started`);
 };

--- a/src/background/configureAutoUpdates/configureAutoUpdates.ts
+++ b/src/background/configureAutoUpdates/configureAutoUpdates.ts
@@ -9,7 +9,7 @@ import pollForUpdates from './pollForUpdates';
 /**
  * Configure automatic updates of the app.
  */
-export default (state: State): void => {
+export default async (state: State): Promise<void> => {
   log.info(`Configuring automatic updates...`);
 
   let checkForUpdatesInterval: NodeJS.Timeout | null = null;
@@ -59,7 +59,7 @@ export default (state: State): void => {
     }, msUntilMidnight);
   });
 
-  checkForUpdatesInterval = pollForUpdates();
+  checkForUpdatesInterval = await pollForUpdates();
 
   log.info(`Configured automatic updates`);
 };

--- a/src/background/configureAutoUpdates/pollForUpdates.ts
+++ b/src/background/configureAutoUpdates/pollForUpdates.ts
@@ -6,10 +6,39 @@ import ms from 'ms';
  * the update and send an OS notification informing the user that a new
  * version is available and can be installed by restarting the app.
  */
-export default (): NodeJS.Timeout => {
-  autoUpdater.checkForUpdatesAndNotify();
+export default async (): Promise<NodeJS.Timeout> => {
+  // It is very common for the auto-updater to encounter an error when checking
+  // for updates. It turns out that end users tend to have lots of sporadic
+  // network issues which can cause problems for an app that is always running.
+  // Examples of network errors we have seen include ERR_NETWORK_IO_SUSPENDED
+  // (which happens when the user's machine goes to sleep), ERR_NETWORK_CHANGED
+  // (which happens when the user's network settings have changed), and
+  // ERR_INTERNET_DISCONNECTED (which happens when the user's network is
+  // disconnected).
+  //
+  // Most (possibly all) of these errors are outside of our control. As such,
+  // there is no need to send an error report. Each error is already logged
+  // by the auto-updater, so we can safely ignore them.
 
-  return setInterval(() => {
-    autoUpdater.checkForUpdatesAndNotify();
-  }, ms(`10 minutes`));
+  try {
+    await autoUpdater.checkForUpdatesAndNotify();
+  } catch (err) {
+    // Ignore errors (see comment above)
+  }
+
+  return setInterval(
+    async () => {
+      try {
+        await autoUpdater.checkForUpdatesAndNotify();
+      } catch (err) {
+        // Ignore errors (see comment above)
+      }
+    },
+    // Some users have experienced issues when `checkForUpdatesAndNotify()` is
+    // called while an update is already being downloaded. To avoid this, we
+    // use a fairly long interval between checks for updates. A long interval
+    // also reduces the number of network requests the user's machine does, and
+    // it reduces noise in the logs.
+    ms(`30 minutes`)
+  );
 };


### PR DESCRIPTION
## The Problem

We have been getting a ton of Sentry alerts from calls to `autoUpdater.checkForUpdatesAndNotify()` that are all related to the user having network connectivity problems. There is nothing we can do about these issues, so the alerts are currently causing a lot of alerting noise.

## The Solution

Catch and ignore errors thrown by calls to `autoUpdater.checkForUpdatesAndNotify()`.

Since we run `checkForUpdatesAndNotify` synchronously when the app starts up, I also moved our `configureAutoUpdates()` function in `background.ts` to be called at the very end so that it won't block any other setup if it happens to take a while to execute the function.

## Other Changes

I also opted to increase the length of time between checks for new versions from 10 minutes to 30 minutes. This was a somewhat arbitrary change not prompted by anything specific, aside from further reducing the number of network requests that our app does and further reducing logging noise.
