### PR TITLE
Fix transparent window bounds on Ubuntu >= 23.10

### DIFF
--- a/src/background/utils/getUbuntuVersion.ts
+++ b/src/background/utils/getUbuntuVersion.ts
@@ -1,0 +1,56 @@
+import { execSync } from 'child_process';
+
+import isLinux from './isLinux';
+
+export type UbuntuVersion = [number, number];
+
+const DISTRIBUTOR_REGEX = /Distributor ID:\s+(.*)/;
+const RELEASE_REGEX = /Release:\s+(.*)/;
+
+export default (): UbuntuVersion | null => {
+  if (!isLinux()) {
+    return null;
+  }
+
+  let stdout: string | null;
+
+  try {
+    stdout = execSync(`lsb_release -a`).toString();
+  } catch (err) {
+    stdout = null;
+  }
+
+  if (!stdout || typeof stdout !== `string`) {
+    return null;
+  }
+
+  const distributorMatch = stdout.match(DISTRIBUTOR_REGEX);
+  const releaseMatch = stdout.match(RELEASE_REGEX);
+
+  if (!distributorMatch || !releaseMatch) {
+    return null;
+  }
+
+  const distributor = distributorMatch.length >= 1 ? distributorMatch[1] : null;
+  const release = releaseMatch.length >= 1 ? releaseMatch[1] : null;
+
+  if (!distributor || !release || distributor.toLowerCase() !== `ubuntu`) {
+    return null;
+  }
+
+  const versionParts = release.split(`.`);
+
+  if (versionParts.length !== 2) {
+    return null;
+  }
+
+  const [year, month] = versionParts.map((part) => {
+    return parseInt(part, 10);
+  });
+
+  if (Number.isNaN(year) || Number.isNaN(month)) {
+    return null;
+  }
+
+  return [year, month];
+};

--- a/src/background/utils/index.ts
+++ b/src/background/utils/index.ts
@@ -4,9 +4,11 @@ import getLogoTemplatePath from './getLogoTemplatePath';
 import getPreloadPath from './getPreloadPath';
 import getShareableMediaSources from './getShareableMediaSources';
 import getSiteUrl from './getSiteUrl';
+import getUbuntuVersion from './getUbuntuVersion';
 import isLinux from './isLinux';
 import isMac from './isMac';
 import isProduction from './isProduction';
+import isUbuntuVersionGreaterOrEqual from './isUbuntuVersionGreaterOrEqual';
 import isWindows from './isWindows';
 import loadUrl from './loadUrl';
 import makeQueryString from './makeQueryString';
@@ -26,9 +28,11 @@ export {
   getPreloadPath,
   getShareableMediaSources,
   getSiteUrl,
+  getUbuntuVersion,
   isLinux,
   isMac,
   isProduction,
+  isUbuntuVersionGreaterOrEqual,
   isWindows,
   loadUrl,
   makeQueryString,

--- a/src/background/utils/isUbuntuVersionGreaterOrEqual.ts
+++ b/src/background/utils/isUbuntuVersionGreaterOrEqual.ts
@@ -1,0 +1,24 @@
+import { UbuntuVersion } from './getUbuntuVersion';
+
+export default (a: UbuntuVersion, b: UbuntuVersion): boolean => {
+  const [aYear, aMonth] = a;
+  const [bYear, bMonth] = b;
+
+  if (aYear < bYear) {
+    return false;
+  }
+
+  if (aYear > bYear) {
+    return true;
+  }
+
+  if (aMonth < bMonth) {
+    return false;
+  }
+
+  if (aMonth > bMonth) {
+    return true;
+  }
+
+  return true;
+};


### PR DESCRIPTION
## The Problem

In Ubuntu 23.10, the OS top bar changed from 27px tall to 32px tall. This caused the audio room widget to be slightly misplaced when aligned to the bottom of the screen because we had to manually adjust the transparent window bounds to account for the OS top bar because the working area size was being incorrectly reported to Electron.

## The Solution

Update the transparent window bounds calculation to support newer versions of Ubuntu with a 32px tall OS top bar.
