### PR TITLE
Add logs to debug issue where `window.electron` is undefined

### DIFF
--- a/src/background/useWindowService/utils/openBrowserWindow.ts
+++ b/src/background/useWindowService/utils/openBrowserWindow.ts
@@ -22,6 +22,7 @@ export default async (
   }
 ): Promise<BrowserWindow> => {
   log(`Get or create`);
+  log(JSON.stringify(windowOptions, null, 2));
 
   const existingWindow = state.windows[windowId];
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,9 +1,12 @@
+/* eslint-disable no-console */
 import { contextBridge, ipcRenderer } from 'electron';
 
 import { ShareableMediaSource } from './types';
 
 // NOTE: values exposed in the main world should be added to window.d.ts
 // in the web app
+
+console.log(`Preload script running...`);
 
 contextBridge.exposeInMainWorld(`electron`, {
   featureFlags: {
@@ -227,3 +230,5 @@ interface IdleChangeEvent {
   isIdle: boolean;
   timestamp: number;
 }
+
+console.log(`Preload script completed`);


### PR DESCRIPTION
## The Problem

We have an Ubuntu 23.04 user who is opening Swivvel in the desktop app, but the app thinks that it is not running in the desktop app because `window.electron` is undefined. So one of the following must be happening

- The preload script is failing to get included in the browser window options (perhaps there is an issue with the path)
- The preload script is getting included but is not running
- The preload script is running but `contextBridge.exposeInMainWorld()` is not working

## The Solution

Add logs so we can verify the path of the preload script and make sure that it is successfully running.
