### PR TITLE
Add keyboard shortcut for toggling mute state

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -5,6 +5,7 @@ import askForMicrophoneAccess from './askForMicrophoneAccess';
 import configureApp from './configureApp';
 import configureAppQuitHandling from './configureAppQuitHandling';
 import configureAutoUpdates from './configureAutoUpdates';
+import configureGlobalKeyboardShortcuts from './configureGlobalKeyboardShortcuts';
 import configureIpcHandlers from './configureIpcHandlers';
 import configureMousePassThroughHandler from './configureMousePassThroughHandler';
 import configureSentry from './configureSentry';
@@ -66,6 +67,7 @@ const run = async (): Promise<void> => {
 
   trayService.createTray();
   handlePowerMonitorStateChanges(state, windowService);
+  configureGlobalKeyboardShortcuts(state);
   await configureAutoUpdates(state);
 
   log.info(`App started`);

--- a/src/background/configureGlobalKeyboardShortcuts.ts
+++ b/src/background/configureGlobalKeyboardShortcuts.ts
@@ -1,0 +1,20 @@
+import { globalShortcut } from 'electron';
+import log from 'electron-log';
+
+import { State } from './types';
+
+export default (state: State): void => {
+  log.info(`Configuring global keyboard shortcuts...`);
+
+  globalShortcut.register(`Alt+Shift+U`, () => {
+    log.info(`Keyboard shortcut pressed: Alt+Shift+U`);
+    const transparentWindow = state.windows.transparent;
+
+    if (transparentWindow && !transparentWindow.isDestroyed()) {
+      log.info(`Sending 'muteToggled' event to transparent window`);
+      transparentWindow.webContents.send(`muteToggled`);
+    }
+  });
+
+  log.info(`Configured global keyboard shortcuts`);
+};

--- a/src/background/configureGlobalKeyboardShortcuts.ts
+++ b/src/background/configureGlobalKeyboardShortcuts.ts
@@ -4,9 +4,9 @@ import log from 'electron-log';
 import { State } from './types';
 
 export default (state: State): void => {
-  log.info(`Configuring global keyboard shortcuts...`);
+  log.info(`Registering mute toggle shortcut (Alt+Shift+U)...`);
 
-  globalShortcut.register(`Alt+Shift+U`, () => {
+  const muteToggleRegistered = globalShortcut.register(`Alt+Shift+U`, () => {
     log.info(`Keyboard shortcut pressed: Alt+Shift+U`);
     const transparentWindow = state.windows.transparent;
 
@@ -16,5 +16,9 @@ export default (state: State): void => {
     }
   });
 
-  log.info(`Configured global keyboard shortcuts`);
+  if (muteToggleRegistered) {
+    log.info(`Registered mute toggle shortcut`);
+  } else {
+    log.info(`Failed to register mute toggle shortcut`);
+  }
 };

--- a/src/background/setUserDataPath.ts
+++ b/src/background/setUserDataPath.ts
@@ -20,7 +20,7 @@ export default (): void => {
     app.setPath(`logs`, logsDev);
 
     // Make sure the main logger writes to the new log path
-    log.transports.file.resolvePath = (): string => {
+    log.transports.file.resolvePathFn = (): string => {
       return path.join(logsDev, `main.log`);
     };
   }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -204,6 +204,17 @@ contextBridge.exposeInMainWorld(`electron`, {
   },
 
   /**
+   * Allows the Electron app to toggle the muted state for the user (if they
+   * are in an audio room).
+   */
+  onMuteToggled: (callback: MuteToggledCallback) => {
+    ipcRenderer.on(`muteToggled`, callback);
+    return (): void => {
+      ipcRenderer.removeListener(`muteToggled`, callback);
+    };
+  },
+
+  /**
    * Trigger a Sentry error on behalf of the user so that we can see their logs
    */
   triggerSentryError: () => {
@@ -225,6 +236,7 @@ type MeetCreatedCallback = (
 ) => void;
 type MeetJoinedCallback = (event: unknown, meetUrl: string) => void;
 type MeetLeftCallback = (event: unknown, meetUrl: string) => void;
+type MuteToggledCallback = (event: unknown) => void;
 
 interface IdleChangeEvent {
   isIdle: boolean;


### PR DESCRIPTION
## The Problem

When someone starts talking to you in Swivvel, it can be annoying to try to get to the widget and click unmute, especially if the widget is currently collapsed.

## The Solution

Register `Alt+Shift+U` as a keyboard shortcut for muting and unmuting.

I tried this keyboard shortcut on Linux, Mac and Windows and it does not seem to be registered on any of them (though individual apps and websites might use it).

## Other Changes

In commit 5efb90a1263c70cd34312be338f377fc44ca42d0 we upgraded the `electron-log` package. One of the changes was to deprecate the `resolvePath` field on the file transport and rename it to `resolvePathFn`. There is still one place we are using the old `resolvePath` name, so I updated it to be `resolvePathFn`.