### PR TITLE
Check if Google Meet window destroyed in more places

### DIFF
--- a/src/background/useWindowService/openGoogleMeetWindow/configureCloseHandler.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/configureCloseHandler.ts
@@ -6,6 +6,10 @@ import { Log } from '../utils';
 export default (window: BrowserWindow, state: State, log: Log): void => {
   log(`Configuring window close handler...`);
 
+  if (window.isDestroyed()) {
+    return;
+  }
+
   window.on(`close`, () => {
     log(`Window close event received`);
     log(`Closing window...`);

--- a/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
@@ -25,6 +25,10 @@ const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
   const windowOptions = getBrowserWindowOptions();
 
   const instantiateWindow: InstantiateWindow = async (window) => {
+    if (window.isDestroyed()) {
+      return window;
+    }
+
     window.webContents.setWindowOpenHandler(({ url }) => {
       return windowOpenRequestHandler(url, log);
     });
@@ -55,6 +59,10 @@ const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
       triggerMeetingCreatedEvent(state, podId, meetingUrlToOpen, log);
     }
 
+    if (window.isDestroyed()) {
+      return window;
+    }
+
     // We need to remove Swivvel and Electron from the user agent. Otherwise,
     // if the user doesn't have a valid google session, they won't be able to
     // join. This is likely because Google will infer that the user is a bot.
@@ -65,6 +73,10 @@ const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
     await loadMeetingUrl(meetingUrlToOpen, window, state, log);
 
     await patchGetDisplayMediaOnUrlChange(window, log);
+
+    if (window.isDestroyed()) {
+      return window;
+    }
 
     // The get-a-link window will try to resize itself to be small, so we
     // need to create the window with a minimum size equal to the desired

--- a/src/background/useWindowService/openGoogleMeetWindow/pollForJoinAndLeaveEvents/triggerMeetingLeftEvent.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/pollForJoinAndLeaveEvents/triggerMeetingLeftEvent.ts
@@ -2,7 +2,7 @@ import { State } from '../../../types';
 import { Log } from '../../utils';
 
 export default (state: State, meetingUrl: string, log: Log): void => {
-  if (state.windows.transparent) {
+  if (state.windows.transparent && !state.windows.transparent.isDestroyed()) {
     log(`Sending meeting left event to transparent window...`);
     state.windows.transparent.webContents.send(`meetLeft`, meetingUrl);
   } else {

--- a/src/background/useWindowService/openGoogleMeetWindow/triggerMeetingCreatedEvent.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/triggerMeetingCreatedEvent.ts
@@ -7,7 +7,7 @@ export default (
   meetingUrl: string,
   log: Log
 ): void => {
-  if (state.windows.transparent) {
+  if (state.windows.transparent && !state.windows.transparent.isDestroyed()) {
     log(`Sending meeting URL to transparent window...`);
     state.windows.transparent.webContents.send(
       `meetCreated`,


### PR DESCRIPTION
## The Problem

We received a couple `TypeError: Object has been destroyed` error alerts in the code that manages the Google Meet window.

## The Solution

Check if the Google Meet window is destroyed before calling any functions on the window object.