### PR TITLE
Allow link to google in meet window for Okta sign in

### DIFF
--- a/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
+++ b/src/background/useWindowService/openGoogleMeetWindow/openGoogleMeetWindow.ts
@@ -103,6 +103,13 @@ const openGoogleMeetWindow: OpenGoogleMeetWindow = async (args) => {
           return false;
         }
 
+        // If someone is signing in to Google via Okta, they will be redirected
+        // to a url on Google domain to consume access token
+        if (url.startsWith(`https://google.com/`)) {
+          log(`Detected navigation to Google URL: ${url}`);
+          return false;
+        }
+
         return null;
       },
     }


### PR DESCRIPTION
## The Problem

To use Google Meet in Swivvel, users need to sign in to Google workspace. Some companies will use okta to sign in. As a part of the okta sign in flow, the user is redirected to a url on the `google.com` domain. Because that domain has not been safelisted, electron kicked it out to the browser which prevents the sign in flow from completing

## The Solution

Allow the url to open in the electron window
