### PR TITLE
Position transparent window using work area `x`

### DIFF
--- a/src/background/utils/getFullscreenBounds.ts
+++ b/src/background/utils/getFullscreenBounds.ts
@@ -20,7 +20,7 @@ interface Bounds {
 export default (): Bounds => {
   const primaryDisplay = screen.getPrimaryDisplay();
 
-  const x = 0;
+  const x = primaryDisplay.workArea.x;
   const width = primaryDisplay.workArea.width;
 
   if (isLinux()) {


### PR DESCRIPTION
## The Problem

A user mentioned that the audio room sidebar widget was extending off the bottom of their screen. They have the following displays:

| Display | Work Area |
|-|-|
| 0 | `{x: 0, y: 0, width: 1600, height: 900}` |
| 1 | `{x: 1600, y: 27, width: 1920, height: 1053}` |

We positioned the transparent window to:

```
{x: 0, y: 27, width: 1920, height: 1053}
```

The primary display is Display 1. Notice how `height`, `width` and `y` were correctly set to the work area position, but `x` was set to 0. The system should be positioning the transparent window to:

```
{x: 1600, y: 27, width: 1920, height: 1053}
```

## The Solution

Use the work area `x` position when positioning the transparent window.