### PR TITLE
Update `onHqRequested` to use `show` param

### DIFF
--- a/src/background/useWindowService/getWindowOpenRequestHandler.ts
+++ b/src/background/useWindowService/getWindowOpenRequestHandler.ts
@@ -22,7 +22,7 @@ export default (callbacks: {
     podId: string | null,
     meetingUrl: string | null
   ) => void;
-  onHqRequested: () => void;
+  onHqRequested: (show: boolean) => void;
   onScreenShareRequested: (
     companyId: string,
     employeeId: string,
@@ -50,7 +50,10 @@ export default (callbacks: {
 
     if (removeQueryParams(url) === `${siteUrl}/electron/hq`) {
       log(`HQ page requested`);
-      callbacks.onHqRequested();
+      const urlParams = parseQueryParams(url);
+      const show = urlParams.get(`show`) === `true`;
+      log(`show=${show}`);
+      callbacks.onHqRequested(show);
       return { action: `deny` };
     }
 

--- a/src/background/useWindowService/useWindowService.ts
+++ b/src/background/useWindowService/useWindowService.ts
@@ -28,9 +28,9 @@ export default (state: State, trayService: TrayService): WindowService => {
         windowOpenRequestHandler,
       });
     },
-    onHqRequested: () => {
+    onHqRequested: (show) => {
       openHqWindow({
-        show: false,
+        show,
         state,
         trayService,
         windowOpenRequestHandler,


### PR DESCRIPTION
## The Problem
We wanted to show the private beta `HomeScreen` page, but we stopped showing the HQ for logging in.

## The Solution
Handle being passed in a `show` prop to open the HQ window when a user is signed in but has no company 