### PR TITLE
Fix transparent window resize on display change on Linux

### DIFF
--- a/src/background/configureTransparentWindowResizeHandler.ts
+++ b/src/background/configureTransparentWindowResizeHandler.ts
@@ -20,14 +20,36 @@ export default (state: State): void => {
       return;
     }
 
+    // The transparent window won't be the correct size while the new
+    // bounds are being calculated, so we hide it to prevent the widget
+    // from temporarily floating in the middle of the screen
+    log.info(`Hiding transparent window`);
+    transparentWindow.hide();
+
+    if (transparentWindow.isDestroyed()) {
+      log.info(`Transparent window destroyed; skipping resize`);
+      return;
+    }
+
     const bounds = await getFullscreenBounds(log.info);
-    const { height, width, x, y } = bounds;
+
+    if (transparentWindow.isDestroyed()) {
+      log.info(`Transparent window destroyed; skipping resize`);
+      return;
+    }
 
     log.info(
       `Resizing transparent window to bounds: ${JSON.stringify(bounds)}`
     );
-    transparentWindow.setSize(width, height, false);
-    transparentWindow.setPosition(x, y, false);
+    transparentWindow.setBounds(bounds, false);
+
+    if (transparentWindow.isDestroyed()) {
+      log.info(`Transparent window destroyed; skipping resize`);
+      return;
+    }
+
+    log.info(`Showing transparent window`);
+    transparentWindow.showInactive();
   };
 
   screen.on(`display-added`, resizeWindow);

--- a/src/background/utils/getFullscreenBounds.ts
+++ b/src/background/utils/getFullscreenBounds.ts
@@ -77,30 +77,27 @@ export default async (log: (msg: string) => void): Promise<Bounds> => {
     setTimeout(() => {
       log(`Reached first timeout for temp window`);
 
-      tempBrowserWindow.on(`maximize`, () => {
-        log(`Temp window 'maximize' event received`);
-        log(`Setting second timeout for temp window`);
-
-        // We also needed to use a timeout after the window was maximized, or
-        // else the bounds would be the un-maximized values. This might be due
-        // to the window animating, or possibly it's a bug in Electron. Since
-        // we don't know the root cause, we don't know how long the timeout
-        // should be, so we just guessed.
-        setTimeout(() => {
-          log(`Reached second timeout for temp window`);
-
-          const bounds = tempBrowserWindow.getBounds();
-          log(`Temp window maximized bounds: ${JSON.stringify(bounds)}`);
-
-          log(`Closing temp window`);
-          tempBrowserWindow.close();
-
-          resolve(bounds);
-        }, 1000);
-      });
-
       log(`Maximizing temp window`);
       tempBrowserWindow.maximize();
+
+      log(`Setting second timeout for temp window`);
+
+      // We also needed to use a timeout after the window was maximized, or
+      // else the bounds would be the un-maximized values. This might be due
+      // to the window animating, or possibly it's a bug in Electron. Since
+      // we don't know the root cause, we don't know how long the timeout
+      // should be, so we just guessed.
+      setTimeout(() => {
+        log(`Reached second timeout for temp window`);
+
+        const bounds = tempBrowserWindow.getBounds();
+        log(`Temp window maximized bounds: ${JSON.stringify(bounds)}`);
+
+        log(`Destroying temp window`);
+        tempBrowserWindow.destroy();
+
+        resolve(bounds);
+      }, 2000);
     }, 2000);
   });
 };


### PR DESCRIPTION
## The Problem

In commit b96ce9d2ab90521a5b8b79321339e62be9e7d77f, we updated the positioning strategy for the transparent window on Linux. Instead of relying on the work area bounds (which is unreliable), we now create a temporary invisible window, maximize it, and then read the bounds.

However, there are now a few issues when the transparent window is resized due to a display change (e.g. plugging in an external monitor):

1. Sometimes the temporary window doesn't get closed so it just hangs around
2. Maximizing the temporary window takes a few seconds, during which time the widget might be floating in the middle of the screen
3. In some cases the widget is rendered off screen after a display change. This seems to happen when the resolution width goes down.

## The Solution

A couple small tweaks address the issues above:

1. Stop relying on the `maximize` event on the temp window. This wasn't consistently firing, which is what was causing the temp windows to hang around sometimes. Instead, just maximize the window and wait two seconds. This isn't ideal, but hopefully two seconds will be enough for the window to maximize successfully so that we can read the new bounds.
2. Hide the transparent window while we are calculating the new bounds so that the widget doesn't appear floating in the middle of the screen
3. Instead of calling `transparentWindow.setSize()` and `transparentWindow.setPosition()` separately, perform the repositioning with a single call to `transparentWindow.setBounds()`. Some OS's will disregard a window resize or reposition if it would cause the window the exceed the bounds of the screen. This is what was causing the widget to render off screen because the `setSize()` was being ignored. By calling `setBounds()`, we can ensure that the window will never be off-screen.
