### PR TITLE
Show the `TransparentWindow` in screenshots

### DIFF
--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -1,7 +1,7 @@
 import { getSiteUrl, isLinux, loadUrl, sleep } from '../../utils';
 import {
-  InstantiateWindow,
   getBrowserWindowLogger,
+  InstantiateWindow,
   openBrowserWindow,
 } from '../utils';
 
@@ -20,10 +20,6 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
 
   const instantiateWindow: InstantiateWindow = async (window) => {
     window.setIgnoreMouseEvents(true, { forward: true });
-
-    // Prevent the transparent window from appearing in screenshots
-    // See: https://www.electronjs.org/docs/latest/api/browser-window#winsetcontentprotectionenable-macos-windows
-    window.setContentProtection(true);
 
     // Show the window but don't focus it because it would be confusing to users
     // if an invisible window took focus.


### PR DESCRIPTION
## The Problem
We didn't show the swivvel widget (the transparent window) in screenshots. But this was more of a negative then a positive. 

> some people are trying to share screenshots with colleagues, and we’re hurting their ability to brag about Swivvel.

## The Solution
Delete the code snippet that removed the widget from screenshots

## Testing
A known bug occurred when screen-shotting the window. I wanted to make sure it didn't get reverted. But when screen-shotting the whole window it works as expected. Outcome:

<img width="1800" alt="Screenshot 2023-11-20 at 10 38 45 AM" src="https://github.com/swivvel/swivvel-electron/assets/78773266/a1edd89b-fbfb-4b41-8cbc-651657549709">

Other screenshot taken for test:
<img width="95" alt="Screenshot 2023-11-20 at 10 38 28 AM" src="https://github.com/swivvel/swivvel-electron/assets/78773266/e0b92f09-9e93-4e78-b1d9-214139990176">
