### PR TITLE
Stop sending auto-update errors to Sentry

### DIFF
--- a/src/background/configureAutoUpdates/pollForUpdates.ts
+++ b/src/background/configureAutoUpdates/pollForUpdates.ts
@@ -9,7 +9,7 @@ import ms from 'ms';
  */
 export default async (): Promise<NodeJS.Timeout> => {
   const checkForUpdatesAndNotify = async (): Promise<void> => {
-    Sentry.configureScope(async (scope) => {
+    Sentry.withScope(async (scope) => {
       // Tag the error so we can ignore it before sending to Sentry. There's a
       // bug where `checkForUpdatesAndNotify()` still throws an error even if
       // it's wrapped in a try/catch, so we have to filter the error manually.

--- a/src/background/configureAutoUpdates/pollForUpdates.ts
+++ b/src/background/configureAutoUpdates/pollForUpdates.ts
@@ -16,7 +16,7 @@ export default async (): Promise<NodeJS.Timeout> => {
   // prevent them from reaching Sentry.
   autoUpdater.autoDownload = false;
 
-  const checkForAndDownloadUpdates = async (): Promise<void> => {
+  const checkForUpdatesAndDownload = async (): Promise<void> => {
     try {
       const result = await autoUpdater.checkForUpdates();
 
@@ -43,11 +43,11 @@ export default async (): Promise<NodeJS.Timeout> => {
     }
   };
 
-  await checkForAndDownloadUpdates();
+  await checkForUpdatesAndDownload();
 
   return setInterval(
     async () => {
-      await checkForAndDownloadUpdates();
+      await checkForUpdatesAndDownload();
     },
     // Some users have experienced issues when `checkForUpdatesAndNotify()` is
     // called while an update is already being downloaded. To avoid this, we

--- a/src/background/configureSentry.ts
+++ b/src/background/configureSentry.ts
@@ -10,6 +10,38 @@ export default (): void => {
     dsn: isProduction()
       ? `https://2dc312dd96e84f3ca06fa0e5e3f96c5e@o4504796289433600.ingest.sentry.io/4504796469657600`
       : `https://c63ffcba511c4cdebd5365c4cb2990f6@o4504796289433600.ingest.sentry.io/4504796459171840`,
+    beforeSend: (event) => {
+      // It is very common for the auto-updater to encounter an error when
+      // checking for updates. It turns out that end users tend to have lots of
+      // sporadic network issues which can cause problems for an app that is
+      // always running. Examples of network errors we have seen include
+      // ERR_NETWORK_IO_SUSPENDED (which happens when the user's machine goes
+      // to sleep), ERR_NETWORK_CHANGED (which happens when the user's network
+      // settings have changed), and ERR_INTERNET_DISCONNECTED (which happens
+      // when the user's network is disconnected).
+      //
+      // Most of these errors are outside of our control, so we are willing to
+      // swallow the error without sending an alert to Sentry. Some errors, such
+      // as missing files in our release, are actionable, but would likely be
+      // caught by someone on the team because we would notice that we're not
+      // getting updated to the latest version. Also, even though the errors
+      // aren't sent to Sentry, they are still logged, so we would be bound to
+      // see the error at some point when reviewing log files.
+      if (event.tags?.autoUpdateError) {
+        const errorMessage = event.exception?.values
+          ?.map((value) => {
+            return value.value;
+          })
+          .filter(Boolean)
+          .join(`, `);
+
+        log.info(`Auto-update error detected, ignoring: ${errorMessage}`);
+
+        return null;
+      }
+
+      return event;
+    },
   });
 
   Sentry.setTag(`swivvel.service`, `electron`);

--- a/src/background/configureSentry.ts
+++ b/src/background/configureSentry.ts
@@ -10,38 +10,6 @@ export default (): void => {
     dsn: isProduction()
       ? `https://2dc312dd96e84f3ca06fa0e5e3f96c5e@o4504796289433600.ingest.sentry.io/4504796469657600`
       : `https://c63ffcba511c4cdebd5365c4cb2990f6@o4504796289433600.ingest.sentry.io/4504796459171840`,
-    beforeSend: (event) => {
-      // It is very common for the auto-updater to encounter an error when
-      // checking for updates. It turns out that end users tend to have lots of
-      // sporadic network issues which can cause problems for an app that is
-      // always running. Examples of network errors we have seen include
-      // ERR_NETWORK_IO_SUSPENDED (which happens when the user's machine goes
-      // to sleep), ERR_NETWORK_CHANGED (which happens when the user's network
-      // settings have changed), and ERR_INTERNET_DISCONNECTED (which happens
-      // when the user's network is disconnected).
-      //
-      // Most of these errors are outside of our control, so we are willing to
-      // swallow the error without sending an alert to Sentry. Some errors, such
-      // as missing files in our release, are actionable, but would likely be
-      // caught by someone on the team because we would notice that we're not
-      // getting updated to the latest version. Also, even though the errors
-      // aren't sent to Sentry, they are still logged, so we would be bound to
-      // see the error at some point when reviewing log files.
-      if (event.tags?.autoUpdateError) {
-        const errorMessage = event.exception?.values
-          ?.map((value) => {
-            return value.value;
-          })
-          .filter(Boolean)
-          .join(`, `);
-
-        log.info(`Auto-update error detected, ignoring: ${errorMessage}`);
-
-        return null;
-      }
-
-      return event;
-    },
   });
 
   Sentry.setTag(`swivvel.service`, `electron`);


### PR DESCRIPTION
## The Problem

In commit b081f9a0d05b6284fd7a69be3978f0b341ec93af, we attempted to stop sending auto-update errors to Sentry because they are too noisy and are almost never actionable. To do so, we wrapped the call to `autoUpdater.checkForUpdatesAndNotify()` in a try/catch. However, this didn't work.

I wrapped `autoUpdater.checkForUpdatesAndNotify()` in a try/catch and added a console log immediately before and after:

```ts
console.log(`+++++++++++++++++++++++++++++++++++++++++ BEFORE`);
try {
  await autoUpdater.checkForUpdates();
} catch (err) {
  //
}
console.log(`+++++++++++++++++++++++++++++++++++++++++ AFTER`);
```

I then ran the app in a state where the download would fail. I received the following output:

```
+++++++++++++++++++++++++++++++++++++++++ BEFORE
14:47:27.219 › Checking for update
14:47:27.812 › Found version 1.2.35 (url: Swivvel.AppImage)
14:47:27.812 › Update available
14:47:27.812 › Downloading update from Swivvel.AppImage
14:47:27.813 › updater cache dir: /home/cedric/.cache/swivvel-updater
+++++++++++++++++++++++++++++++++++++++++ AFTER
14:47:27.981 › Cannot download differentially, fallback to full download: Error: Received data length 108517 is not equal to expected 108522
    at FileWithEmbeddedBlockMapDifferentialDownloader.readRemoteBytes (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/electron-updater/out/differentialDownloader/DifferentialDownloader.js:238:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async FileWithEmbeddedBlockMapDifferentialDownloader.download (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/electron-updater/out/differentialDownloader/FileWithEmbeddedBlockMapDifferentialDownloader.js:12:35)
    at async Object.task (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/electron-updater/out/AppImageUpdater.js:56:21)
    at async AppImageUpdater.executeDownload (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/electron-updater/out/AppUpdater.js:538:13)
14:47:29.042 › Download speed: 58702562 - Downloaded 56.00831291194308% (58702562/104810445)
14:47:29.801 › Download speed: 59585244 - Downloaded 100% (104810445/104810445)
14:47:29.830 › Error: Error: sha512 checksum mismatch, expected 038LOntR3P+8NKdxAYeObt27kHvUA/RLhOZ8LdkDf0wkTO8jeWE/MB5eKEeh5EIIbLbKaLpOguePo4X4rF7tQg==, got SUwnM942DnGjb2NhrQotvhw1EyW6pDeig2YIxle7hHTIS5o+8nNsoHJ5GHszGP3gNo8rKCojo9/x11IVS4udcg==
    at newError (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/builder-util-runtime/out/index.js:47:19)
    at DigestTransform.validate (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:327:40)
    at DigestTransform._flush (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:313:22)
    at DigestTransform.final [as _final] (node:internal/streams/transform:132:10)
    at callFinal (node:internal/streams/writable:698:12)
    at prefinish (node:internal/streams/writable:710:7)
    at finishMaybe (node:internal/streams/writable:720:5)
    at DigestTransform.end (node:internal/streams/writable:634:5)
    at ProgressCallbackTransform.onend (node:internal/streams/readable:705:10)
    at Object.onceWrapper (node:events:628:28)
14:47:29.831 › Error in auto-updater: Error: sha512 checksum mismatch, expected 038LOntR3P+8NKdxAYeObt27kHvUA/RLhOZ8LdkDf0wkTO8jeWE/MB5eKEeh5EIIbLbKaLpOguePo4X4rF7tQg==, got SUwnM942DnGjb2NhrQotvhw1EyW6pDeig2YIxle7hHTIS5o+8nNsoHJ5GHszGP3gNo8rKCojo9/x11IVS4udcg==
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
Error: sha512 checksum mismatch, expected 038LOntR3P+8NKdxAYeObt27kHvUA/RLhOZ8LdkDf0wkTO8jeWE/MB5eKEeh5EIIbLbKaLpOguePo4X4rF7tQg==, got SUwnM942DnGjb2NhrQotvhw1EyW6pDeig2YIxle7hHTIS5o+8nNsoHJ5GHszGP3gNo8rKCojo9/x11IVS4udcg==
    at newError (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/builder-util-runtime/out/index.js:47:19)
    at DigestTransform.validate (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:327:40)
    at DigestTransform._flush (/tmp/.mount_Swivve1LBTJx/resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:313:22)
    at DigestTransform.final [as _final] (node:internal/streams/transform:132:10)
    at callFinal (node:internal/streams/writable:698:12)
    at prefinish (node:internal/streams/writable:710:7)
    at finishMaybe (node:internal/streams/writable:720:5)
    at DigestTransform.end (node:internal/streams/writable:634:5)
    at ProgressCallbackTransform.onend (node:internal/streams/readable:705:10)
    at Object.onceWrapper (node:events:628:28)
14:47:29.836 › Sentry addGlobalEventProcessor called
14:47:29.836 › Reading all log files...
14:47:29.839 › Attaching log files: ["/home/cedric/.config/Swivvel/logs/main.log","/home/cedric/.config/Swivvel/logs/transparent.log","/home/cedric/.config/Swivvel/logs/transparent.old.log"]
```

Notice that the error is thrown _after_ the `++++ AFTER` log line. This means that the downloader did not await something, resulting in the code execution continuing asynchronously and nullifying the try/catch.

## The Solution

The only way I could find to successfully await the download was to set `autoUpdater.autoDownload = false` and then to call `autoUpdater.checkForUpdates()` and `autoUpdater.downloadUpdate()` separately.

Doing this resulted in the try/catch successfully catching the download error and all download code running within the `+++ BEFORE` and `+++ AFTER` log lines:

```
+++++++++++++++++++++++++++++++++++++++++ BEFORE
15:09:55.420 › Checking for update
15:09:55.421 › Configured automatic updates
15:09:55.956 › Found version 1.2.35 (url: Swivvel.AppImage)
15:09:55.956 › Update available
15:09:55.957 › Downloading update from Swivvel.AppImage
15:09:55.957 › updater cache dir: /home/cedric/.cache/swivvel-updater
15:09:56.131 › Cannot download differentially, fallback to full download: Error: Received data length 108517 is not equal to expected 108522
    at FileWithEmbeddedBlockMapDifferentialDownloader.readRemoteBytes (/tmp/.mount_SwivveQw8Bx9/resources/app.asar/node_modules/electron-updater/out/differentialDownloader/DifferentialDownloader.js:238:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async FileWithEmbeddedBlockMapDifferentialDownloader.download (/tmp/.mount_SwivveQw8Bx9/resources/app.asar/node_modules/electron-updater/out/differentialDownloader/FileWithEmbeddedBlockMapDifferentialDownloader.js:12:35)
    at async Object.task (/tmp/.mount_SwivveQw8Bx9/resources/app.asar/node_modules/electron-updater/out/AppImageUpdater.js:56:21)
    at async AppImageUpdater.executeDownload (/tmp/.mount_SwivveQw8Bx9/resources/app.asar/node_modules/electron-updater/out/AppUpdater.js:538:13)
    at async /tmp/.mount_SwivveQw8Bx9/resources/app.asar/compiled/background/configureAutoUpdates/pollForUpdates.js:41:21
15:09:57.183 › Download speed: 59331350 - Downloaded 56.66484957677643% (59390681/104810445)
15:09:57.974 › Download speed: 58455351 - Downloaded 100% (104810445/104810445)
15:09:58.001 › Error: Error: sha512 checksum mismatch, expected 038LOntR3P+8NKdxAYeObt27kHvUA/RLhOZ8LdkDf0wkTO8jeWE/MB5eKEeh5EIIbLbKaLpOguePo4X4rF7tQg==, got SUwnM942DnGjb2NhrQotvhw1EyW6pDeig2YIxle7hHTIS5o+8nNsoHJ5GHszGP3gNo8rKCojo9/x11IVS4udcg==
    at newError (/tmp/.mount_SwivveQw8Bx9/resources/app.asar/node_modules/builder-util-runtime/out/index.js:47:19)
    at DigestTransform.validate (/tmp/.mount_SwivveQw8Bx9/resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:327:40)
    at DigestTransform._flush (/tmp/.mount_SwivveQw8Bx9/resources/app.asar/node_modules/builder-util-runtime/out/httpExecutor.js:313:22)
    at DigestTransform.final [as _final] (node:internal/streams/transform:132:10)
    at callFinal (node:internal/streams/writable:698:12)
    at prefinish (node:internal/streams/writable:710:7)
    at finishMaybe (node:internal/streams/writable:720:5)
    at DigestTransform.end (node:internal/streams/writable:634:5)
    at ProgressCallbackTransform.onend (node:internal/streams/readable:705:10)
    at Object.onceWrapper (node:events:628:28)
15:09:58.001 › Error in auto-updater: Error: sha512 checksum mismatch, expected 038LOntR3P+8NKdxAYeObt27kHvUA/RLhOZ8LdkDf0wkTO8jeWE/MB5eKEeh5EIIbLbKaLpOguePo4X4rF7tQg==, got SUwnM942DnGjb2NhrQotvhw1EyW6pDeig2YIxle7hHTIS5o+8nNsoHJ5GHszGP3gNo8rKCojo9/x11IVS4udcg==
+++++++++++++++++++++++++++++++++++++++++ AFTER
```

I also validated that a download without an error still works:

```
+++++++++++++++++++++++++++++++++++++++++ BEFORE
15:13:27.741 › Checking for update
15:13:27.741 › Configured automatic updates
15:13:28.284 › Found version 1.2.35 (url: Swivvel.AppImage)
15:13:28.285 › Update available
15:13:28.285 › Downloading update from Swivvel.AppImage
15:13:28.286 › updater cache dir: /home/cedric/.cache/swivvel-updater
15:13:28.443 › Cannot download differentially, fallback to full download: Error: Received data length 108517 is not equal to expected 108522
    at FileWithEmbeddedBlockMapDifferentialDownloader.readRemoteBytes (/tmp/.mount_SwivveCkXSsZ/resources/app.asar/node_modules/electron-updater/out/differentialDownloader/DifferentialDownloader.js:238:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async FileWithEmbeddedBlockMapDifferentialDownloader.download (/tmp/.mount_SwivveCkXSsZ/resources/app.asar/node_modules/electron-updater/out/differentialDownloader/FileWithEmbeddedBlockMapDifferentialDownloader.js:12:35)
    at async Object.task (/tmp/.mount_SwivveCkXSsZ/resources/app.asar/node_modules/electron-updater/out/AppImageUpdater.js:56:21)
    at async AppImageUpdater.executeDownload (/tmp/.mount_SwivveCkXSsZ/resources/app.asar/node_modules/electron-updater/out/AppUpdater.js:538:13)
    at async /tmp/.mount_SwivveCkXSsZ/resources/app.asar/compiled/background/configureAutoUpdates/pollForUpdates.js:41:21
15:13:29.574 › Download speed: 59833031 - Downloaded 57.086897207620865% (59833031/104810445)
15:13:30.348 › Download speed: 59081423 - Downloaded 100% (104810445/104810445)
15:13:30.349 › New version 1.2.35 has been downloaded to /home/cedric/.cache/swivvel-updater/pending/Swivvel.AppImage
15:13:30.350 › Update downloaded
15:13:30.351 › Scheduling app relaunch for 2023-11-21T05:00:00.000Z...
+++++++++++++++++++++++++++++++++++++++++ AFTER
```