### PR TITLE
Re-enable content protection to prevent blue bar on windows

### DIFF
--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -21,6 +21,10 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
   const instantiateWindow: InstantiateWindow = async (window) => {
     window.setIgnoreMouseEvents(true, { forward: true });
 
+    // Without this, a blue bar appears at the top of the transparent window
+    // on Windows
+    window.setContentProtection(true);
+
     // Show the window but don't focus it because it would be confusing to users
     // if an invisible window took focus.
     window.showInactive();


### PR DESCRIPTION
## The Problem

In commit 7906dc07df272e71ebf24f57b0668eace47bdfe0, we removed the following setting on the transparent window:

```ts
window.setContentProtection(true);
```

The intention was to make it so that users could take screenshots of the widget when filing bug reports.

However, there was an unintended consequence. Windows users started reporting a blue bar at the top of their screen:

![image](https://github.com/swivvel/swivvel-electron/assets/119253005/150476b9-7086-47b8-bc1b-2a69b148005a)

## The Solution

I have no clue why this blue bar appears when content protection is off, but I'm turning content protection back on for now to fix the bug, and then we can take some time to figure out why the blue bar is appearing.
