### PR TITLE
Add "Upgrade" option to tray menu

### DIFF
--- a/src/background/useTrayService/utils/getBaseMenuItems.ts
+++ b/src/background/useTrayService/utils/getBaseMenuItems.ts
@@ -9,10 +9,10 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
   const menuItems: Array<MenuItemConstructorOptions> = [];
 
   menuItems.push({
-    label: `Upgrade`,
+    label: `Check for Updates`,
     type: `normal`,
     click: async (): Promise<void> => {
-      log.info(`Detected click on Upgrade menu item`);
+      log.info(`Detected click on Check for Updates menu item`);
 
       const result = await autoUpdater.checkForUpdates();
 
@@ -21,12 +21,21 @@ export default (state: State): Array<MenuItemConstructorOptions> => {
           state.windows.transparent &&
           !state.windows.transparent.isDestroyed()
         ) {
-          dialog.showMessageBoxSync(state.windows.transparent, {
-            title: `New version available`,
-            message: result
-              ? `Swivvel version ${result.updateInfo.version} is available. Click "OK" to download the update and restart Swivvel.`
-              : `A new version of Swivvel is available. Click "OK" to download the update and restart Swivvel.`,
-          });
+          const buttonIndex = dialog.showMessageBoxSync(
+            state.windows.transparent,
+            {
+              title: `New version available`,
+              message: result
+                ? `Swivvel version ${result.updateInfo.version} is available. Click "OK" to download the update and restart Swivvel.`
+                : `A new version of Swivvel is available. Click "OK" to download the update and restart Swivvel.`,
+              buttons: [`Cancel`, `OK`],
+            }
+          );
+          log.info(`Button index clicked: ${buttonIndex}`);
+          if (buttonIndex === 0) {
+            log.info(`Cancel button clicked. Aborting upgrade.`);
+            return;
+          }
         }
         await autoUpdater.downloadUpdate(result.cancellationToken);
         quitApp(state, { quitAndInstall: true });


### PR DESCRIPTION
## The Problem

We frequently have to tell users to upgrade the desktop app. Every running version of the app will upgrade automatically at midnight, but sometimes we need users to upgrade before then, such as when we pushed a bug fix.

Right now, the only way to ensure that a user is on the latest version is to tell them to restart the app twice (once to download the update, a second time to install it). This is somewhat awkward.

## The Solution

Add a "Check for Updates" option to the tray menu that checks for a new update and prompts the user to download it if one is available.

![image](https://github.com/swivvel/swivvel-electron/assets/119253005/382aa85a-363f-4a41-92a7-5a69487b2580)

![image](https://github.com/swivvel/swivvel-electron/assets/119253005/b58709d5-37b3-45ed-96e4-6fad0776821e)

![image](https://github.com/swivvel/swivvel-electron/assets/119253005/2fcdec1d-2102-4c86-9b34-0585bde40903)
