### PR TITLE
Allow screenshots of transparent window on Mac

### DIFF
--- a/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
+++ b/src/background/useWindowService/openTransparentWindow/openTransparentWindow.ts
@@ -1,4 +1,4 @@
-import { getSiteUrl, isLinux, loadUrl, sleep } from '../../utils';
+import { getSiteUrl, isLinux, isWindows, loadUrl, sleep } from '../../utils';
 import {
   getBrowserWindowLogger,
   InstantiateWindow,
@@ -21,9 +21,11 @@ const openTransparentWindow: OpenTransparentWindow = async (args) => {
   const instantiateWindow: InstantiateWindow = async (window) => {
     window.setIgnoreMouseEvents(true, { forward: true });
 
-    // Without this, a blue bar appears at the top of the transparent window
-    // on Windows
-    window.setContentProtection(true);
+    if (isWindows()) {
+      // Without this, a blue bar appears at the top of the transparent window
+      // on Windows. See: https://github.com/electron/electron/issues/40286
+      window.setContentProtection(true);
+    }
 
     // Show the window but don't focus it because it would be confusing to users
     // if an invisible window took focus.


### PR DESCRIPTION
## The Problem

In commit 7906dc07df272e71ebf24f57b0668eace47bdfe0, we removed the following setting on the transparent window:

```ts
window.setContentProtection(true);
```

The intention was to make it so that users could take screenshots of the widget when filing bug reports.

However, there was an unintended consequence. Windows users started reporting a blue bar at the top of their screen:

![image](https://github.com/swivvel/swivvel-electron/assets/119253005/150476b9-7086-47b8-bc1b-2a69b148005a)

In commit 52fd914e863dca61b02429d49eb0f306a3c2fe97, we re-enabled content protection to quickly fix the bug and remove the blue bar. However, this is only a bug on Windows, so we don't need to enable content protection on other operating systems.

## The Solution

Only enable content protection if the app is running on Windows.

Ideally we would find a way to disable content protection on Windows, but I found an open GitHub issue about this problem: https://github.com/electron/electron/issues/40286. Rather than dig deeper ourselves, I'm just going to wait and see if there is any progress on that GitHub issue. We can revisit later if the issue stays quiet.
