### PR TITLE
Log OS and hardware specs when app starts

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -13,6 +13,7 @@ import configureTransparentWindowResizeHandler from './configureTransparentWindo
 import getDeepLinkHandler from './getDeepLinkHandler';
 import handlePowerMonitorStateChanges from './handlePowerMonitorStateChanges';
 import listenForDeepLinks from './listenForDeepLinks';
+import logSystemInfo from './logSystemInfo';
 import pollForIdleTime from './pollForIdleTime';
 import setUserDataPath from './setUserDataPath';
 import { State } from './types';
@@ -26,8 +27,7 @@ setUserDataPath();
 
 const run = async (): Promise<void> => {
   log.info(`App v=${app.getVersion()} starting...`);
-  log.info(`User Data: ${app.getPath(`userData`)}`);
-  log.info(`Logs: ${app.getPath(`logs`)}`);
+  logSystemInfo();
 
   // Call at the beginning so that all exceptions are captured
   configureSentry();

--- a/src/background/logSystemInfo.ts
+++ b/src/background/logSystemInfo.ts
@@ -1,0 +1,16 @@
+import os from 'os';
+
+import { app } from 'electron';
+import log from 'electron-log';
+
+export default (): void => {
+  log.info(`User Data: ${app.getPath(`userData`)}`);
+  log.info(`Logs: ${app.getPath(`logs`)}`);
+  log.info(`CPU: ${JSON.stringify(os.cpus())}`);
+  log.info(`Memory: ${Math.round(os.totalmem() / 1024 / 1024 / 1024)} GB`);
+  log.info(`Free Memory: ${Math.round(os.freemem() / 1024 / 1024 / 1024)} GB`);
+  log.info(`Type: ${os.type()}`);
+  log.info(`Platform: ${os.platform()}`);
+  log.info(`Release: ${os.release()}`);
+  log.info(`Uptime: ${Math.round(os.uptime() / 60 / 60)} hours`);
+};


### PR DESCRIPTION
## The Problem

Some users have mentioned that the app is causing their computer to run slowly. It would be handy to have an easy way to get information about each user's OS and hardware to help identify a possible pattern and try to reproduce the issue.

## The Solution

Log some information about the user's system when the app starts.
