### PR TITLE
Prevent temp transparent window from stealing focus

### DIFF
--- a/src/background/utils/getFullscreenBounds.ts
+++ b/src/background/utils/getFullscreenBounds.ts
@@ -59,9 +59,11 @@ export default async (log: (msg: string) => void): Promise<Bounds> => {
     const tempBrowserWindow = new BrowserWindow({
       closable: false,
       frame: false,
+      show: false,
       transparent: true,
     });
 
+    tempBrowserWindow.showInactive();
     tempBrowserWindow.setIgnoreMouseEvents(true);
 
     const initialBounds = tempBrowserWindow.getBounds();


### PR DESCRIPTION
## The Problem

In commit b96ce9d2ab90521a5b8b79321339e62be9e7d77f, we updated the positioning strategy for the transparent window on Linux. Instead of relying on the work area bounds (which is unreliable), we now create a temporary invisible window, maximize it, and then read the bounds.

However, when the temporary transparent window is created, it automatically gets focus. This steals focus away from whatever other window the user had open, which is somewhat annoying.

## The Solution

Prevent the temporary transparent window from stealing focus by opening it hidden and then using `showInactive()` to show it without grabbing focus.
