### PR TITLE
Add a comment about referencing the global shortcut

### DIFF
--- a/src/background/configureGlobalKeyboardShortcuts.ts
+++ b/src/background/configureGlobalKeyboardShortcuts.ts
@@ -6,6 +6,8 @@ import { State } from './types';
 export default (state: State): void => {
   log.info(`Registering mute toggle shortcut (Alt+Shift+U)...`);
 
+  // We reference this shortcut in the Mute/Unmute button tooltip, so it's
+  // important that if we change this shortcut we also update the tooltip there
   const muteToggleRegistered = globalShortcut.register(`Alt+Shift+U`, () => {
     log.info(`Keyboard shortcut pressed: Alt+Shift+U`);
     const transparentWindow = state.windows.transparent;


### PR DESCRIPTION
## The Problem
Now that we reference the global shortcut in the mute icons tooltip, there are two places to update if we ever change the tooltip.

## The Solution
Leave a comment reminder so if we do change it the developer will now know to update there as well.
