### PR TITLE
Create universal Mac builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,12 @@
         "NSCameraUsageDescription": "Your camera will only be accessed when you open a video breakout.",
         "com.apple.security.device.audio-input": true,
         "com.apple.security.device.camera": true
+      },
+      "target": {
+        "target": "default",
+        "arch": [
+          "universal"
+        ]
       }
     },
     "win": {


### PR DESCRIPTION
## The Problem

Some users have been prompted to install Rosetta in order to run Swivvel on Mac. Rosetta allows ARM Macs to run software built for Intel Macs. We should be able to support both.

## The Solution

Add a flag to output universal Mac builds.
