### PR TITLE
Add `err` log for `loadUrl`

### DIFF
--- a/src/background/utils/loadUrl.ts
+++ b/src/background/utils/loadUrl.ts
@@ -39,6 +39,7 @@ const loadUrl = async (
   } catch (err) {
     log(`Failed to load URL: ${urlNoParams}`);
     log(`onError=${options.onError}`);
+    log(`err=${err}`);
 
     if (browserWindow.isDestroyed()) {
       log(`Skipping error handling: window is destroyed`);


### PR DESCRIPTION
## The Problem
Sometimes the google meet window will close unexpectadly and throw a error, but we have no insight to the actual error being thrown.

## The Solution
Add `err` to the catch logs in `loadUrl.ts`
