### PR TITLE
Add deep link handler to join audio room for pod

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -52,7 +52,7 @@ const run = async (): Promise<void> => {
 
   configureApp();
   configureAppQuitHandling(state);
-  listenForDeepLinks(state, getDeepLinkHandler(logInService));
+  listenForDeepLinks(state, getDeepLinkHandler(logInService, windowService));
 
   await app.whenReady();
   await askForMicrophoneAccess();

--- a/src/background/getDeepLinkHandler.ts
+++ b/src/background/getDeepLinkHandler.ts
@@ -1,15 +1,20 @@
 import log from 'electron-log';
 
 import { LogInService } from './useLogInService';
+import { WindowService } from './useWindowService';
+import { parseQueryParams } from './utils';
 
 const convertDeepLinkUrlToHttps = (url: string): string => {
   return url.replace(/^swivvel:\/\//, `https://`);
 };
 
 export default (
-  logInService: LogInService
+  logInService: LogInService,
+  windowService: WindowService
 ): ((url: string) => Promise<void>) => {
   return async (url) => {
+    log.info(`Deep link handler: ${url}`);
+
     // See main repo README for description of desktop log in flow
     if (url.includes(`/api/auth/callback`)) {
       log.info(`Running log in callback handler...`);
@@ -21,6 +26,21 @@ export default (
       await logInService.handleLogInOAuthCallback(deepLinkUrl);
 
       log.info(`Log in callback handler complete`);
+    }
+
+    if (url.includes(`/join-audio-room-for-pod`)) {
+      log.info(`Running join channel callback handler...`);
+      const transparentWindow = await windowService.openTransparentWindow();
+
+      const urlParams = parseQueryParams(url);
+      const podId = urlParams.get(`podId`) || null;
+      log.info(`urlParams: ${JSON.stringify(Array.from(urlParams.entries()))}`);
+      log.info(`podId=${podId}`);
+
+      if (podId) {
+        log.info(`Sending joinAudioRoomForPod event to transparent window`);
+        transparentWindow.webContents.send(`joinAudioRoomForPod`, podId);
+      }
     }
   };
 };

--- a/src/background/listenForDeepLinks.ts
+++ b/src/background/listenForDeepLinks.ts
@@ -36,7 +36,7 @@ export default (state: State, deepLinkHandler: (url: string) => void): void => {
     log.info(`Acquired the single instance lock`);
 
     app.on(`second-instance`, (event, commandLine) => {
-      const url = commandLine?.pop()?.slice(0, -1);
+      const url = commandLine?.pop();
       const urlNoParams = url ? removeQueryParams(url) : null;
 
       log.info(`Deep link detected from second-instance: ${urlNoParams}`);


### PR DESCRIPTION
## The Problem

We are building a feature that posts a Slack message when a new Swivvel session is started. This message will have a link to join the Swivvel session. This requires a deep link in to the Electron app that runs the code to join the audio room for a specific pod.

## The Solution

Add a new `/join-audio-room-for-pod?podId=xxx` deep link that sends the existing `joinAudioRoomForPod` event to the transparent window.

This commit also fixes a bug where we were slicing the last character off of the deep link when we should not have been.